### PR TITLE
Indic all: Fix typo in adjacent marks description

### DIFF
--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -752,7 +752,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -703,7 +703,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -703,7 +703,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -758,7 +758,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -1075,7 +1075,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -778,7 +778,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -757,7 +757,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -774,7 +774,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -713,7 +713,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -706,7 +706,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -741,7 +741,7 @@ Fourth, any subsequences of marks that include a "Nukta" and a
 "Halant" or Vedic sign must be reordered so that the "Nukta" appears
 first.
 
-This means that the subsequence "Halant,Nukta" is reodered to
+This means that the subsequence "Halant,Nukta" is reordered to
 "Nukta,Halant" and that the subsequence "_Vedic_sign_,Nukta" is
 reordered to "Nukta,_Vedic_sign".
 


### PR DESCRIPTION
Minor spelling fix for the clarifications made for issue #34. `reodered` -> `reordered`.

The new explanation reads well!