### PR TITLE
Base clarification [WIP]

### DIFF
--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -78,6 +78,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.
@@ -142,7 +147,7 @@ replaces the default glyphs with superscript variants.
 
 Marks and dependent vowels are further labeled with a mark-placement
 subclass, which indicates where the glyph will be placed with respect
-to the base character to which it is attached. The actual position of
+to the syllable base to which it is attached. The actual position of
 the glyphs is determined by the lookups found in the font's GPOS
 table, however, the shaping rules for Indic scripts require that the
 shaping engine be able to identify marks by their general
@@ -159,10 +164,10 @@ There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
 respect to the base consonant to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -305,7 +310,7 @@ track. These include:
     a specific, implicit sequence.
 	
   - Whether the below-base forms feature is applied only to consonants
-    before the base consonant, only to consonants after the base
+    before the syllable base, only to consonants after the base
     consonant, or to both.
 	
   - The ordering positions for dependent vowels
@@ -362,12 +367,35 @@ begin with either a consonant or an independent vowel.
 If the syllable begins with a consonant, then the consonant that
 provides the vowel sound is referred to as the "base" consonant. If
 the syllable begins with an independent vowel, that vowel is the
-syllable's only vowel sound and, by definition, there is no "base"
-consonant. 
+syllable's only vowel sound and serves as the "base". 
 
 > Note: A consonant that is not accompanied by a dependent vowel (matra) sign
 > carries the script's inherent vowel sound. This vowel sound is changed
 > by a dependent vowel (matra) sign following the consonant.
+
+From the shaping engine's perspective, the main distinction between a
+syllable with a base consonant and a syllable with an
+independent-vowel base is that a syllable with an independent-vowel
+base is less likely to include additional consonants in special forms
+and less likely to include depedendent vowel signs
+(matras). Therefore, in the common case, vowel-based syllables may
+involve less reordering, substitution feature applications, and other
+processing than consonant-based syllables.
+
+In some languages and orthographies, vowel-based syllables are
+not permitted to include additional consonants or matras, and certain
+GSUB substitution features do not occur. However, there are often
+known exceptions, and real-world text makes no such guarantees. 
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 Generally speaking, the base consonant is the final consonant of the
 syllable and its vowel sound designates the end of the syllable. This
@@ -497,6 +525,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > identification class, and that the other "combining consonant"
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
+
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -642,7 +676,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -664,19 +698,21 @@ which a codepoint might be reordered, across all of the Indic
 scripts. It includes some ordering categories not utilized in
 Bengali. 
 
-The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
-vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+The basic positions (left to right) are "Reph"
+(`POS_RA_TO_BECOME_REPH`), dependent vowels (matras) and consonants
+positioned before the base consonant or syllable base
+(`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base consonant
+or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
-(`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
-and syllable-modifying or Vedic signs (`POS_SMVD`).
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base
+consonant or syllable base (`POS_POSTBASE_CONSONANT`), syllable-final
+consonants (`POS_FINAL_CONSONANT`), and syllable-modifying or Vedic
+signs (`POS_SMVD`).
 
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -690,7 +726,29 @@ For a definition of the "base" consonant, refer to step 2.1, which follows.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
+
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base, and it should be tagged
+as `POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a standalone sequence or other syllable that begins with a placeholder
+or dotted circle, the placeholder or dotted circle will always serve
+as the syllable base, and it should be tagged as
+`POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a syllable that begins with a consonant, the shaping engine must
+determine the base consonant by a script-specific algorithm.
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 The base consonant is defined as the consonant in a consonant-based
 syllable that carries the syllable's vowel sound. That vowel sound
@@ -698,13 +756,7 @@ will either be provided by the script's inherent vowel (in which case
 it is not written with a separate character) or the sound will be designated
 by the addition of a dependent-vowel (matra) sign.
 
-Vowel-based syllables, standalone sequences, and broken text runs will
-not have base consonants.
-
-> Note: For consistency with consonant-based syllables, shaping
-> engines may choose to treat the independent vowel of a vowel-based
-> syllable as a "pseudo-base" or surrogate base consonant.
->
+<!--- >
 > Because vowel-based syllables will not include consonants and
 > because independent vowels do not take on special forms or require
 > reordering, many of the steps that follow will involve no
@@ -712,7 +764,7 @@ not have base consonants.
 > still be sorted and their marks handled correctly, and GSUB and GPOS
 > lookups must be applied. These steps of the shaping process follow
 > the same rules that are employed for consonant-based syllables.
-
+--->
 
 While performing the base-consonant search, shaping engines may
 also encounter special-form consonants, including below-base
@@ -720,7 +772,7 @@ consonants and post-base consonants. Each of these special-form
 consonants must also be tagged (`POS_BELOWBASE_CONSONANT`,
 `POS_POSTBASE_CONSONANT`, respectively). 
 
-Any pre-base-reordering consonant (such as a pre-base-reodering "Ra")
+Any pre-base-reordering consonant (such as a pre-base-reordering "Ra")
 encountered during the base-consonant search must be tagged
 `POS_POSTBASE_CONSONANT`. 
  
@@ -771,10 +823,10 @@ Bengali includes one post-base consonant.
 
 Bengali includes two below-base consonant forms:
 
-  - "Halant,Ra" (after the base consonant) and "Ra,Halant" (in a
+  - "Halant,Ra" (after the syllable base) and "Ra,Halant" (in a
     non-syllable-initial position) take on the "Raphala" form.
-  - "Ba,Halant" (before the base consonant) and "Halant,Ba" (after the
-    base consonant) take on the "Baphala" form.
+  - "Ba,Halant" (before the syllable base) and "Halant,Ba" (after the
+    syllable base) take on the "Baphala" form.
 	
 
 ![Raphala composition](/images/bengali/bengali-raphala.png)
@@ -783,10 +835,10 @@ Bengali includes two below-base consonant forms:
 
 > Note: Because Bengali employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base.
 > 
 > During the base-consonant search, only the "Halant,_consonant_" 
-> pattern following the base consonant for these below-base forms will
+> pattern following the syllable base for these below-base forms will
 > be encountered. Step 2.5 below ensures that the "_consonant_,Halant"
 > pattern preceding the base consonant for these below-base forms will
 > also be tagged correctly.
@@ -849,7 +901,7 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be
+Fifth, consonants that occur before the syllable base must be
 tagged. Excluding initial "Ra,Halant" sequences that will become "Reph"s:
 
   - If the consonant has a below-base form, tag it as
@@ -871,10 +923,10 @@ tagged. Excluding initial "Ra,Halant" sequences that will become "Reph"s:
 
 Bengali includes two below-base consonant forms:
 
-  - "Halant,Ra" (after the base consonant) and "Ra,Halant" (in a
+  - "Halant,Ra" (after the syllable base) and "Ra,Halant" (in a
     non-syllable-initial position) take on the "Raphala" form.
-  - "Ba,Halant" (before the base consonant) and "Halant,Ba" (after the
-    base consonant) take on the "Baphala" form.
+  - "Ba,Halant" (before the syllable base) and "Halant,Ba" (after the
+    syllable base) take on the "Baphala" form.
 	
 
 ![Raphala composition](/images/bengali/bengali-raphala.png)
@@ -884,13 +936,13 @@ Bengali includes two below-base consonant forms:
 
 > Note: Because Bengali employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search in 2.1, any instances of the
-> "Halant,_consonant_"  pattern following the base consonant for these
+> "Halant,_consonant_"  pattern following the syllable base for these
 > below-base forms will be encountered. The tagging in this step
-> ensures that the "_consonant_,Halant" pattern preceding the base
-> consonant for these below-base forms will also be tagged correctly.
+> ensures that the "_consonant_,Halant" pattern preceding the syllable
+> base for these below-base forms will also be tagged correctly.
 
 
 #### 2.6: Reph ####
@@ -904,7 +956,7 @@ Sixth, initial "Ra,Halant" sequences that will become "Reph"s must be tagged wit
 #### 2.7: Final consonants ####
 
 Seventh, all final consonants must be tagged. Consonants that occur
-after the base consonant _and_ after a dependent vowel (matra) sign
+after the syllable base _and_ after a dependent vowel (matra) sign
 must be tagged with  `POS_FINAL_CONSONANT`.
 
 > Note: Final consonants occur only in Sinhala and should not be
@@ -928,29 +980,29 @@ Marks in the `BINDU`, `VISARGA`, `AVAGRAHA`, `CANTILLATION`,
 be tagged with `POS_SMVD`. 
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final
@@ -1048,10 +1100,10 @@ The `blwf` feature replaces below-base-consonant glyphs with any
 special forms. Bengali includes two below-base consonant
 forms:
 
-  - "Halant,Ra" (after the base consonant) and "Ra,Halant" (in a
+  - "Halant,Ra" (after the syllable base) and "Ra,Halant" (in a
     non-syllable-initial position) take on the "Raphala" form.
-  - "Ba,Halant" (before the base consonant) and "Halant,Ba" (after the
-    base consonant) take on the "Baphala" form. 
+  - "Ba,Halant" (before the syllable base) and "Halant,Ba" (after the
+    syllable base) take on the "Baphala" form. 
 
 Because Bengali incorporates the `BLWF_MODE_PRE_AND_POST` shaping
 characteristic, any pre-base consonants and any post-base consonants
@@ -1072,9 +1124,9 @@ characteristic.
 #### 3.9: half ####
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
-base consonant with "half forms" of the consonant glyphs. There are
-three exceptions to the default behavior, for which the shaping engine
-must test:
+base consonant or syllable base with "half forms" of the consonant
+glyphs. There are three exceptions to the default behavior, for which
+the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been tagged for
     the `rphf` feature earlier, must not be tagged for potential
@@ -1133,10 +1185,10 @@ must be applied after the `half` feature.
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -1150,16 +1202,24 @@ because it was almost certainly lost in the preceding GSUB stage.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -1176,8 +1236,8 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
 
 ![Pre-base matra reordering](/images/bengali/bengali-matra-position.png)
 
@@ -1186,14 +1246,14 @@ consonant, and all half forms.
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Bengali incorporates the `REPH_POS_AFTER_SUBJOINED`
 shaping characteristic, this final position is immediately after the
-base consonant and any subjoined (below-base consonant or below-base
+syllable base and any subjoined (below-base consonant or below-base
 dependent vowel) forms.
 
   - If the syllable does not have a base consonant (such as a syllable
-    based on an independent vowel), then the final "Reph" position is
-    immediately before the first character tagged with the
-    `POS_BEFORE_POST` position or any later position in the sort
-    order.
+    based on an independent vowel or placeholder), then the final
+    "Reph" position is immediately before the first character tagged
+    with the `POS_BEFORE_POST` position or any later position in the
+    sort order.
 
     -- If there are no characters tagged with `POS_BEFORE_POST` or
        later positions, then "Reph" is positioned at the end of the
@@ -1209,7 +1269,7 @@ left of "Halant", to allow for potential matching with `abvs` or
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to immediately before
-the base consonant.
+the base consonant or syllable base.
   
 Bengali does not use pre-base-reordering consonants, so this step will
 involve no work when processing `<bng2>` text. It is included here in order

--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -162,7 +162,7 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the base consonant or syllable base to which it is attached:
 
   - `LEFT_POSITION` matras are positioned to the left of the syllable base.
   - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
@@ -418,16 +418,16 @@ carry no vowel. Instead, they affect syllable pronunciation by
 combining with the base consonant (e.g., "_thr_" or "_spl_").
 
 Three consonants in Bengali are allowed to occur after the base
-consonant: "Ya", "Ba", and "Ra". When these consonants occur after the
-base consonant, they take on special forms.
+consonant or syllable base: "Ya", "Ba", and "Ra". When these consonants occur after the
+base consonant or syllable base, they take on special forms.
 
-A "Ya" after the base consonant takes on the "Yaphala" form.
+A "Ya" after the base consonant or syllable base takes on the "Yaphala" form.
 
 > Note: some fonts may also implement the "Yaphala" form for a
 > post-base "Yya" (`U+09DF`).
 
-A "Ba" after the base consonants takes on the below-base "Baphala"
-form. A "Ba" before the base consonant will take on the below-base
+A "Ba" after the base consonant or syllable bases takes on the below-base "Baphala"
+form. A "Ba" before the base consonant or syllable base will take on the below-base
 "Baphala" form unless it is the first pre-base consonant in the syllable.
 
 As with other Indic scripts, the consonant "Ra" receives special
@@ -439,8 +439,8 @@ mark-like forms.
     consonant in the syllable). This rule is synonymous with the
     `REPH_MODE_IMPLICIT` characteristic mentioned earlier.
 
-  - A non-initial "Ra" before the base consonant or a "Ra" after the
-    base consonant takes on the below-base form "Raphala."
+  - A non-initial "Ra" before the base consonant or syllable base or a "Ra" after the
+    base consonant or syllable base takes on the below-base form "Raphala."
   
 "Reph" characters must be reordered after the
 syllable-identification stage is complete. 
@@ -840,7 +840,7 @@ Bengali includes two below-base consonant forms:
 > During the base-consonant search, only the "Halant,_consonant_" 
 > pattern following the syllable base for these below-base forms will
 > be encountered. Step 2.5 below ensures that the "_consonant_,Halant"
-> pattern preceding the base consonant for these below-base forms will
+> pattern preceding the base consonant or syllable base for these below-base forms will
 > also be tagged correctly.
 
 
@@ -1237,7 +1237,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra reordering](/images/bengali/bengali-matra-position.png)
 
@@ -1421,7 +1421,7 @@ The old Indic shaping model also did not recognize the
 `BLWF_MODE_PRE_AND_POST` shaping characteristic. Instead, `<beng>`
 was treated as if it followed the `BLWF_MODE_POST_ONLY`
 characteristic. In other words, below-base form substitutions were
-only applied to consonants after the base consonant.
+only applied to consonants after the base consonant or syllable base.
 
 In addition, for some scripts, left-side dependent vowel marks
 (matras) were not repositioned during the final reordering
@@ -1444,7 +1444,7 @@ the `<beng>` script tag and it is known that the font in use supports
 only the `<bng2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant when it is
+below-base consonants occuring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -346,13 +346,36 @@ begin with either a consonant or an independent vowel.
 
 If the syllable begins with a consonant, then the consonant that
 provides the vowel sound is referred to as the "base" consonant. If
-the syllable begins with an independent vowel, that vowel is the
-syllable's only vowel sound and, by definition, there is no "base"
-consonant. 
+the syllable begins with an independent vowel, that independent vowel
+is the syllable's only vowel sound and serves as the "base". 
 
 > Note: A consonant that is not accompanied by a dependent vowel (matra) sign
 > carries the script's inherent vowel sound. This vowel sound is changed
 > by a dependent vowel (matra) sign following the consonant.
+
+From the shaping engine's perspective, the main distinctions between a
+syllable with a base consonant and a syllable with an
+independent-vowel base are that a syllable with a base consonant may
+also contain multiple other consonants, including consonants that take
+on special forms depending on where in the syllable they
+appear, and that a syllable with an independent-vowel base will not
+include any depedendent vowel signs (matras).
+
+Because of these distinctions, consonant-based syllables require
+significantly more processing than vowel-based syllables. 
+
+> Note: Shaping engines may choose to treat independent-vowel bases
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> Because valid vowel-based syllables are generally simpler,
+> processing a vowel-based syllable should follow all of the logic
+> described for consonant-based syllables in the steps that follow,
+> but only trigger actions where mark-handling is involved.
+>
+> Implementations taking this approach, however, should recognize that
+> making guarantees about the correctness of the results or about
+> language-specific tests is out of scope for this document.
 
 Generally speaking, the base consonant is the final consonant of the
 syllable and its vowel sound designates the end of the syllable. This
@@ -464,6 +487,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > identification class, and that the other "combining consonant"
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
+
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1353,8 +1353,13 @@ for post-base consonants.
 The old Indic shaping model also did not recognize the
 `BLWF_MODE_PRE_AND_POST` shaping characteristic. Instead, `<deva>`
 was treated as if it followed the `BLWF_MODE_POST_ONLY`
-characteristic. In other words, below-base form substitutions were
-only applied to consonants after the base consonant.
+characteristic — with a single exception made for non-syllable-initial
+"Ra,Halant".
+
+In other words, a non-syllable-initial "Ra,Halant" sequence would
+trigger a below-base form substitution, but all other below-base form
+substitutions were applied only to consonants after the base
+consonant.
 
 In addition, for some scripts, left-side dependent vowel marks
 (matras) were not repositioned during the final reordering

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -775,7 +775,7 @@ The algorithm for determining the base consonant is
 
 Devanagari includes one below-base consonant form.
 
-  - Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
+  - "Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
     (before the syllable base, but in a non-syllable-initial
     position) will take on the "Rakaar" form. 
 	
@@ -863,7 +863,7 @@ that will become "Reph"s:
 
 Devanagari includes one below-base consonant form.
 
-  - Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
+  - "Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
     (before the syllable base, but in a non-syllable-initial
     position) will take on the "Rakaar" form. 
 	

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -408,7 +408,7 @@ mark-like forms.
     below-base form "Rakaar." 
 	
 	
-In addition, "Rra,Halant" sequences that precede the base consonant
+In addition, "Rra,Halant" sequences that precede the base consonant or syllable base
 may take on a form known as the "eyelash Ra." 
 
 > Note: In `<dev2>` text runs, this substitution is canonically
@@ -1096,7 +1096,7 @@ the shaping engine must test:
 ![Half-form formation](/images/devanagari/devanagari-half.png)
 
 In addition, the sequence "Rra,Halant" (occurring before the base
-consonant) will take on the "eyelash Ra" form. Because this
+consonant or syllable base) will take on the "eyelash Ra" form. Because this
 substitution is defined as the canonical half form of "Rra" in `<dev2>`, the
 shaping engine does not need to implement any special handling to
 support it. 
@@ -1194,7 +1194,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra positioning](/images/devanagari/devanagari-matra-position.png)
 
@@ -1255,7 +1255,7 @@ above-base marks or contextually appropriate mark-and-base ligatures.
 ![Above-base substitutions](/images/devanagari/devanagari-abvs.png)
 
 The `blws` feature replaces below-base-consonant glyphs with special
-presentation forms. This usually includes replacing base consonants that
+presentation forms. This usually includes replacing base consonants or syllable bases that
 are adjacent to the below-base-consonant form "Rakaar" with contextual
 ligatures.
 
@@ -1359,7 +1359,7 @@ characteristic — with a single exception made for non-syllable-initial
 In other words, a non-syllable-initial "Ra,Halant" sequence would
 trigger a below-base form substitution, but all other below-base form
 substitutions were applied only to consonants after the base
-consonant.
+consonant or syllable base.
 
 In addition, for some scripts, left-side dependent vowel marks
 (matras) were not repositioned during the final reordering
@@ -1389,7 +1389,7 @@ the `<deva>` script tag and it is known that the font in use supports
 only the `<dev2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant when it is
+below-base consonants occuring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -74,6 +74,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.
@@ -145,12 +150,12 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the syllable base to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -293,7 +298,7 @@ track. These include:
     a specific, implicit sequence.
 	
   - Whether the below-base forms feature is applied only to consonants
-    before the base consonant, only to consonants after the base
+    before the syllable base, only to consonants after the base
     consonant, or to both.
 	
   - The ordering positions for dependent vowels
@@ -353,29 +358,29 @@ is the syllable's only vowel sound and serves as the "base".
 > carries the script's inherent vowel sound. This vowel sound is changed
 > by a dependent vowel (matra) sign following the consonant.
 
-From the shaping engine's perspective, the main distinctions between a
+From the shaping engine's perspective, the main distinction between a
 syllable with a base consonant and a syllable with an
-independent-vowel base are that a syllable with a base consonant may
-also contain multiple other consonants, including consonants that take
-on special forms depending on where in the syllable they
-appear, and that a syllable with an independent-vowel base will not
-include any depedendent vowel signs (matras).
+independent-vowel base is that a syllable with an independent-vowel
+base is less likely to include additional consonants in special forms
+and less likely to include depedendent vowel signs
+(matras). Therefore, in the common case, vowel-based syllables may
+involve less reordering, substitution feature applications, and other
+processing than consonant-based syllables.
 
-Because of these distinctions, consonant-based syllables require
-significantly more processing than vowel-based syllables. 
+In some languages and orthographies, vowel-based syllables are
+not permitted to include additional consonants or matras, and certain
+GSUB substitution features do not occur. However, there are often
+known exceptions, and real-world text makes no such guarantees. 
 
-> Note: Shaping engines may choose to treat independent-vowel bases
+> Note: Shaping engines may choose to treat independent-vowel bases 
 > like base consonants for the sake of simplicity or code
 > reuse.
 >
-> Because valid vowel-based syllables are generally simpler,
-> processing a vowel-based syllable should follow all of the logic
-> described for consonant-based syllables in the steps that follow,
-> but only trigger actions where mark-handling is involved.
->
-> Implementations taking this approach, however, should recognize that
-> making guarantees about the correctness of the results or about
-> language-specific tests is out of scope for this document.
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 Generally speaking, the base consonant is the final consonant of the
 syllable and its vowel sound designates the end of the syllable. This
@@ -635,7 +640,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -657,19 +662,21 @@ which a codepoint might be reordered, across all of the Indic
 scripts. It includes some ordering categories not utilized in
 Devanagari. 
 
-The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
-vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+The basic positions (left to right) are "Reph"
+(`POS_RA_TO_BECOME_REPH`), dependent vowels (matras) and consonants
+positioned before the base consonant or syllable base
+(`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base consonant
+or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
-(`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
-and syllable-modifying or Vedic signs (`POS_SMVD`).
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base
+consonant or syllable base (`POS_POSTBASE_CONSONANT`), syllable-final
+consonants (`POS_FINAL_CONSONANT`), and syllable-modifying or Vedic
+signs (`POS_SMVD`).
 
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -683,7 +690,29 @@ For a definition of the "base" consonant, refer to step 2.1, which follows.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
+
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base, and it should be tagged
+as `POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a standalone sequence or other syllable that begins with a placeholder
+or dotted circle, the placeholder or dotted circle will always serve
+as the syllable base, and it should be tagged as
+`POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a syllable that begins with a consonant, the shaping engine must
+determine the base consonant by a script-specific algorithm.
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 The base consonant is defined as the consonant in a consonant-based
 syllable that carries the syllable's vowel sound. That vowel sound
@@ -691,21 +720,15 @@ will either be provided by the script's inherent vowel (in which case
 it is not written with a separate character) or the sound will be designated
 by the addition of a dependent-vowel (matra) sign.
 
-Vowel-based syllables, standalone-sequences, and broken text runs will
-not have base consonants.
 
-> Note: For consistency with consonant-based syllables, shaping
-> engines may choose to treat the independent vowel of a vowel-based
-> syllable as a "pseudo-base" or surrogate base consonant.
->
-> Because vowel-based syllables will not include consonants and
+<!--- > Because vowel-based syllables will not include consonants and
 > because independent vowels do not take on special forms or require
 > reordering, many of the steps that follow will involve no
 > work for a vowel-based syllable. However, vowel-based syllables must
 > still be sorted and their marks handled correctly, and GSUB and GPOS
 > lookups must be applied. These steps of the shaping process follow
 > the same rules that are employed for consonant-based syllables.
-
+--->
 
 While performing the base-consonant search, shaping engines may
 also encounter special-form consonants, including below-base
@@ -713,7 +736,7 @@ consonants and post-base consonants. Each of these special-form
 consonants must also be tagged (`POS_BELOWBASE_CONSONANT`,
 `POS_POSTBASE_CONSONANT`, respectively). 
 
-Any pre-base-reordering consonant (such as a pre-base-reodering "Ra")
+Any pre-base-reordering consonant (such as a pre-base-reordering "Ra")
 encountered during the base-consonant search must be tagged
 `POS_POSTBASE_CONSONANT`. 
  
@@ -752,8 +775,8 @@ The algorithm for determining the base consonant is
 
 Devanagari includes one below-base consonant form.
 
-  - Halant,Ra" (occurring after the base consonant) and "Ra,Halant"
-    (before the base consonant, but in a non-syllable-initial
+  - Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
+    (before the syllable base, but in a non-syllable-initial
     position) will take on the "Rakaar" form. 
 	
 > Note: the sequence "Rra,Halant" (occurring before the base
@@ -765,12 +788,12 @@ Devanagari includes one below-base consonant form.
 
 > Note: Because Devanagari employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search, only the "Halant,_consonant_" 
-> pattern following the base consonant for these below-base forms will
+> pattern following the syllable base for these below-base forms will
 > be encountered. Step 2.5 below ensures that the "_consonant_,Halant"
-> pattern preceding the base consonant for these below-base forms will
+> pattern preceding the syllable base for these below-base forms will
 > also be tagged correctly.
 
 
@@ -817,7 +840,7 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be tagged
+Fifth, consonants that occur before the syllable base must be tagged
 with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences
 that will become "Reph"s: 
 
@@ -840,8 +863,8 @@ that will become "Reph"s:
 
 Devanagari includes one below-base consonant form.
 
-  - Halant,Ra" (occurring after the base consonant) and "Ra,Halant"
-    (before the base consonant, but in a non-syllable-initial
+  - Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
+    (before the syllable base, but in a non-syllable-initial
     position) will take on the "Rakaar" form. 
 	
 > Note: the sequence "Rra,Halant" (occurring before the base
@@ -853,13 +876,13 @@ Devanagari includes one below-base consonant form.
 
 > Note: Because Devanagari employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search in 2.1, any instances of the
-> "Halant,_consonant_"  pattern following the base consonant for these
+> "Halant,_consonant_"  pattern following the syllable base for these
 > below-base forms will be encountered. The tagging in this step
-> ensures that the "_consonant_,Halant" pattern preceding the base
-> consonant for these below-base forms will also be tagged correctly.
+> ensures that the "_consonant_,Halant" pattern preceding the syllable
+> base for these below-base forms will also be tagged correctly.
 
 
 #### 2.6: Reph ####
@@ -873,7 +896,7 @@ Sixth, initial "Ra,Halant" sequences that will become "Reph"s must be tagged wit
 #### 2.7: Final consonants ####
 
 Seventh, all final consonants must be tagged. Consonants that occur
-after the base consonant _and_ after a dependent vowel (matra) sign
+after the syllable base _and_ after a dependent vowel (matra) sign
 must be tagged with  `POS_FINAL_CONSONANT`.
 
 > Note: Final consonants occur only in Sinhala and should not be
@@ -894,29 +917,29 @@ Marks in the `BINDU`, `VISARGA`, `AVAGRAHA`, `CANTILLATION`,
 be tagged with `POS_SMVD`. 
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final sort order.
@@ -1024,8 +1047,8 @@ The `blwf` feature replaces below-base-consonant glyphs with any
 special forms. Devanagari includes one below-base consonant
 form:
 
-  - "Halant,Ra" (occurring after the base consonant) or "Ra,Halant"
-    (before the base consonant, but in a non-syllable-initial position) will
+  - "Halant,Ra" (occurring after the syllable base) or "Ra,Halant"
+    (before the syllable base, but in a non-syllable-initial position) will
     take on the "Rakaar" form.
 	
 If the active font contains ligatures for the consonant adjacent to
@@ -1051,9 +1074,9 @@ characteristic.
 #### 3.9: half ####
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
-base consonant with "half forms" of the consonant glyphs. There are
-four exceptions to the default behavior, for which the shaping engine
-must test:
+base consonant or syllable base with "half forms" of the consonant
+glyphs. There are four exceptions to the default behavior, for which
+the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been tagged for
     the `rphf` feature earlier, must not be tagged for potential
@@ -1119,10 +1142,10 @@ must be applied after the `half` feature.
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -1136,16 +1159,24 @@ because it was almost certainly lost in the preceding GSUB stage.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -1162,8 +1193,8 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
 
 ![Pre-base matra positioning](/images/devanagari/devanagari-matra-position.png)
 
@@ -1173,7 +1204,7 @@ consonant, and all half forms.
 position. Because Devanagari incorporates the `REPH_POS_BEFORE_POST`
 shaping characteristic, this final position is immediately before any
 independent post-base consonant forms (meaning the first post-base
-consonant that has not formed a ligature with the base consonant).
+consonant that has not formed a ligature with the syllable base).
 
   - If the syllable does not have any post-base consonants, then the
     final "Reph" position is immediately before the first post-base
@@ -1185,7 +1216,7 @@ consonant that has not formed a ligature with the base consonant).
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to immediately before
-the base consonant.
+the base consonant or syllable base.
   
   
 #### 4.5: Initial matras ####

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -759,7 +759,7 @@ The algorithm for determining the base consonant is
 
 Gujarati includes one below-base consonant form.
 
-  - Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
+  - "Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
     (before the syllable base, but in a non-syllable-initial
     position) will take on the "Rakaar" form. 
 	
@@ -859,7 +859,7 @@ that will become "Reph"s:
 
 Gujarati includes one below-base consonant form.
 
-  - Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
+  - "Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
     (before the syllable base, but in a non-syllable-initial
     position) will take on the "Rakaar" form. 
 	

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -141,12 +141,12 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the syllable base to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -288,7 +288,7 @@ track. These include:
     a specific, implicit sequence.
 	
   - Whether the below-base forms feature is applied only to consonants
-    before the base consonant, only to consonants after the base
+    before the syllable base, only to consonants after the base
     consonant, or to both.
 	
   - The ordering positions for dependent vowels
@@ -348,6 +348,30 @@ consonant.
 > Note: A consonant that is not accompanied by a dependent vowel (matra) sign
 > carries the script's inherent vowel sound. This vowel sound is changed
 > by a dependent vowel (matra) sign following the consonant.
+
+From the shaping engine's perspective, the main distinction between a
+syllable with a base consonant and a syllable with an
+independent-vowel base is that a syllable with an independent-vowel
+base is less likely to include additional consonants in special forms
+and less likely to include depedendent vowel signs
+(matras). Therefore, in the common case, vowel-based syllables may
+involve less reordering, substitution feature applications, and other
+processing than consonant-based syllables.
+
+In some languages and orthographies, vowel-based syllables are
+not permitted to include additional consonants or matras, and certain
+GSUB substitution features do not occur. However, there are often
+known exceptions, and real-world text makes no such guarantees. 
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 Generally speaking, the base consonant is the final consonant of the
 syllable and its vowel sound designates the end of the syllable. This
@@ -450,6 +474,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > identification class, and that the other "combining consonant"
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
+
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -592,7 +622,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -614,19 +644,21 @@ which a codepoint might be reordered, across all of the Indic
 scripts. It includes some ordering categories not utilized in
 Gujarati. 
 
-The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
-vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+The basic positions (left to right) are "Reph"
+(`POS_RA_TO_BECOME_REPH`), dependent vowels (matras) and consonants
+positioned before the base consonant or syllable base
+(`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base consonant
+or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
-(`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
-and syllable-modifying or Vedic signs (`POS_SMVD`).
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base
+consonant or syllable base (`POS_POSTBASE_CONSONANT`), syllable-final
+consonants (`POS_FINAL_CONSONANT`), and syllable-modifying or Vedic
+signs (`POS_SMVD`).
 
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -640,7 +672,29 @@ For a definition of the "base" consonant, refer to step 2.1, which follows.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
+
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base, and it should be tagged
+as `POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a standalone sequence or other syllable that begins with a placeholder
+or dotted circle, the placeholder or dotted circle will always serve
+as the syllable base, and it should be tagged as
+`POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a syllable that begins with a consonant, the shaping engine must
+determine the base consonant by a script-specific algorithm.
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 The base consonant is defined as the consonant in a consonant-based
 syllable that carries the syllable's vowel sound. That vowel sound
@@ -651,18 +705,14 @@ by the addition of a dependent-vowel (matra) sign.
 Vowel-based syllables, standalone-sequences, and broken text runs will
 not have base consonants.
 
-> Note: For consistency with consonant-based syllables, shaping
-> engines may choose to treat the independent vowel of a vowel-based
-> syllable as a "pseudo-base" or surrogate base consonant.
->
-> Because vowel-based syllables will not include consonants and
+<!--- > Because vowel-based syllables will not include consonants and
 > because independent vowels do not take on special forms or require
 > reordering, many of the steps that follow will involve no
 > work for a vowel-based syllable. However, vowel-based syllables must
 > still be sorted and their marks handled correctly, and GSUB and GPOS
 > lookups must be applied. These steps of the shaping process follow
 > the same rules that are employed for consonant-based syllables.
-
+--->
 
 While performing the base-consonant search, shaping engines may
 also encounter special-form consonants, including below-base
@@ -670,7 +720,7 @@ consonants and post-base consonants. Each of these special-form
 consonants must also be tagged (`POS_BELOWBASE_CONSONANT`,
 `POS_POSTBASE_CONSONANT`, respectively). 
 
-Any pre-base-reordering consonant (such as a pre-base-reodering "Ra")
+Any pre-base-reordering consonant (such as a pre-base-reordering "Ra")
 encountered during the base-consonant search must be tagged
 `POS_POSTBASE_CONSONANT`. 
  
@@ -709,18 +759,18 @@ The algorithm for determining the base consonant is
 
 Gujarati includes one below-base consonant form.
 
-  - "Halant,Ra" (occurring after the base consonant) or "Ra,Halant"
-    (before the base consonant, but in a non-syllable-initial
+  - Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
+    (before the syllable base, but in a non-syllable-initial
     position) will take on the "Rakaar" form. 
 	
 > Note: Because Gujarati employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search, only the "Halant,_consonant_" 
-> pattern following the base consonant for these below-base forms will
+> pattern following the syllable base for these below-base forms will
 > be encountered. Step 2.5 below ensures that the "_consonant_,Halant"
-> pattern preceding the base consonant for these below-base forms will
+> pattern preceding the syllable base for these below-base forms will
 > also be tagged correctly.
 
 
@@ -786,8 +836,9 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be tagged
-with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences that will become "Reph"s:
+Fifth, consonants that occur before the syllable base must be tagged
+with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences
+that will become "Reph"s: 
 
   - If the consonant has a below-base form, tag it as
           `POS_BELOWBASE_CONSONANT`. 
@@ -808,19 +859,19 @@ with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences that will 
 
 Gujarati includes one below-base consonant form.
 
-  - "Halant,Ra" (occurring after the base consonant) or "Ra,Halant"
-    (before the base consonant, but in a non-syllable-initial
+  - Halant,Ra" (occurring after the syllable base) and "Ra,Halant"
+    (before the syllable base, but in a non-syllable-initial
     position) will take on the "Rakaar" form. 
 	
 > Note: Because Gujarati employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search in 2.1, any instances of the
-> "Halant,_consonant_"  pattern following the base consonant for these
+> "Halant,_consonant_"  pattern following the syllable base for these
 > below-base forms will be encountered. The tagging in this step
-> ensures that the "_consonant_,Halant" pattern preceding the base
-> consonant for these below-base forms will also be tagged correctly.
+> ensures that the "_consonant_,Halant" pattern preceding the syllable
+> base for these below-base forms will also be tagged correctly.
 
 
 #### 2.6: Reph ####
@@ -854,29 +905,29 @@ Marks in the `BINDU`, `VISARGA`, `AVAGRAHA`, `CANTILLATION`,
 be tagged with `POS_SMVD`. 
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final sort order.
@@ -982,8 +1033,8 @@ The `blwf` feature replaces below-base-consonant glyphs with any
 special forms. Gujarati includes one below-base consonant
 form:
 
-  - "Halant,Ra" (occurring after the base consonant) or "Ra,Halant"
-    (before the base consonant, but in a non-syllable-initial position) will
+  - "Halant,Ra" (occurring after the syllable base) or "Ra,Halant"
+    (before the syllable base, but in a non-syllable-initial position) will
     take on the "Rakaar" form.
 	
 If the active font contains ligatures for the consonant adjacent to
@@ -1009,9 +1060,9 @@ characteristic.
 #### 3.9: half ####
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
-base consonant with "half forms" of the consonant glyphs. There are
-four exceptions to the default behavior, for which the shaping engine
-must test:
+base consonant or syllable base with "half forms" of the consonant
+glyphs. There are four exceptions to the default behavior, for which
+the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been tagged for
     the `rphf` feature earlier, must not be tagged for potential
@@ -1075,10 +1126,10 @@ must be applied after the `half` feature.
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -1092,16 +1143,24 @@ because it was almost certainly lost in the preceding GSUB stage.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -1118,8 +1177,8 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
 
 ![Pre-base matra positioning](/images/gujarati/gujarati-matra-position.png)
 
@@ -1129,7 +1188,7 @@ consonant, and all half forms.
 position. Because Gujarati incorporates the `REPH_POS_BEFORE_POST`
 shaping characteristic, this final position is immediately before any
 independent post-base consonant forms (meaning the first post-base
-consonant that has not formed a ligature with the base consonant).
+consonant that has not formed a ligature with the syllable base).
 
   - If the syllable does not have any post-base consonants, then the
     final "Reph" position is immediately before the first post-base
@@ -1142,7 +1201,7 @@ consonant that has not formed a ligature with the base consonant).
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to immediately before
-the base consonant.
+the base consonant or syllable base.
   
 Gujarati does not use pre-base-reordering consonants, so this step will
 involve no work when processing `<gjr2>` text. It is included here in order

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -70,6 +70,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -384,7 +384,7 @@ rule is synonymous with the `BASE_POS_LAST` characteristic mentioned
 earlier. 
 
 Valid consonant-based syllables may include one or more additional 
-consonants that precede the base consonant. Each of these
+consonants that precede the base consonant or syllable base. Each of these
 other, pre-base consonants will be followed by the "Halant" mark, which
 indicates that they carry no vowel. They affect pronunciation by
 combining with the base consonant (e.g., "_str_", "_pl_") but they
@@ -890,7 +890,7 @@ Sixth, initial "Ra,Halant" sequences that will become "Reph"s must be tagged wit
 #### 2.7: Final consonants ####
 
 Seventh, all final consonants must be tagged. Consonants that occur
-after the base consonant _and_ after a dependent vowel (matra) sign
+after the base consonant or syllable base _and_ after a dependent vowel (matra) sign
 must be tagged with  `POS_FINAL_CONSONANT`.
 
 > Note: Final consonants occur only in Sinhala and should not be
@@ -1183,7 +1183,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra positioning](/images/gujarati/gujarati-matra-position.png)
 
@@ -1248,7 +1248,8 @@ above-base marks or contextually appropriate mark-and-base ligatures.
 ![abvs feature application](/images/gujarati/gujarati-abvs.png)
 
 The `blws` feature replaces below-base-consonant glyphs with special
-presentation forms. This usually includes replacing base consonants that
+presentation forms. This usually includes replacing base consonants or
+syllable bases that
 are adjacent to the below-base-consonant form "Rakaar" with contextual
 ligatures.
 
@@ -1346,7 +1347,7 @@ The old Indic shaping model also did not recognize the
 `BLWF_MODE_PRE_AND_POST` shaping characteristic. Instead, `<gujr>`
 was treated as if it followed the `BLWF_MODE_POST_ONLY`
 characteristic. In other words, below-base form substitutions were
-only applied to consonants after the base consonant.
+only applied to consonants after the base consonant or syllable base.
 
 In addition, for some scripts, left-side dependent vowel marks
 (matras) were not repositioned during the final reordering
@@ -1370,7 +1371,7 @@ the `<gujr>` script tag and it is known that the font in use supports
 only the `<gjr2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant when it is
+below-base consonants occuring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -428,15 +428,15 @@ rule is synonymous with the `BASE_POS_LAST` characteristic mentioned
 earlier. 
 
 Valid consonant-based syllables may include one or more additional 
-consonants that precede the base consonant. Each of these
+consonants that precede the base consonant or syllable base. Each of these
 other, pre-base consonants will be followed by the "Halant" mark, which
 indicates that they carry no vowel. They affect pronunciation by
-combining with the base consonant (e.g., "_str_", "_pl_") but they
+combining with the base consonant or syllable base (e.g., "_str_", "_pl_") but they
 do not add a vowel sound.
 
 Gurmukhi also includes special consonants that can occur after the
-base consonant. These post-base consonants will also be separated from
-the base consonant by a "Halant" mark; the algorithm for correctly
+base consonant or syllable base. These post-base consonants will also be separated from
+the base consonant or syllable base by a "Halant" mark; the algorithm for correctly
 identifying the base consonant includes a test to recognize these sequences
 and not mis-identify the base consonant.
 
@@ -449,8 +449,8 @@ mark-like forms.
     consonant in the syllable). This rule is synonymous with the
     `REPH_MODE_IMPLICIT` characteristic mentioned earlier.
 
-  - A "Ra,Halant" sequence before the base consonant or a "Halant,Ra"
-    sequence after the base consonant may be replaced with a
+  - A "Ra,Halant" sequence before the base consonant or syllable base or a "Halant,Ra"
+    sequence after the base consonant or syllable base may be replaced with a
     below-base mark.
   
 > Note: "Reph" substitutions are rare in Gurmukhi text. `<gur2>` fonts may
@@ -824,11 +824,11 @@ Gurmukhi includes one post-base form:
 
 Gurmukhi includes three below-base consonant forms:
 
-  - "Halant,Ra" (after the base consonant) and "Ra,Halant" (in a
+  - "Halant,Ra" (after the base consonant or syllable base) and "Ra,Halant" (in a
     non-syllable-initial position) take on a below-base form.
-  - "Halant,Ha" (after the base consonant) and "Ha,Halant" (in a
+  - "Halant,Ha" (after the base consonant or syllable base) and "Ha,Halant" (in a
     non-syllable-initial position) take on a below-base form. 
-  - "Halant,Va" (after the base consonant) and "Va,Halant" (in a
+  - "Halant,Va" (after the base consonant or syllable base) and "Va,Halant" (in a
     non-syllable-initial position) take on a below-base form. 
 
 Gurmukhi also includes the CONSONANT_MEDIAL subclass, used only for "Yakash"
@@ -925,11 +925,11 @@ that will become "Reph"s:
 
 Gurmukhi includes three below-base consonant forms:
 
-  - "Halant,Ra" (after the base consonant) and "Ra,Halant" (in a
+  - "Halant,Ra" (after the base consonant or syllable base) and "Ra,Halant" (in a
     non-syllable-initial position) take on a below-base form.
-  - "Halant,Ha" (after the base consonant) and "Ha,Halant" (in a
+  - "Halant,Ha" (after the base consonant or syllable base) and "Ha,Halant" (in a
     non-syllable-initial position) take on a below-base form. 
-  - "Halant,Va" (after the base consonant) and "Va,Halant" (in a
+  - "Halant,Va" (after the base consonant or syllable base) and "Va,Halant" (in a
     non-syllable-initial position) take on a below-base form. 
 
 > Note: Because Gurmukhi employs the `BLWF_MODE_PRE_AND_POST` shaping
@@ -1098,11 +1098,11 @@ The `blwf` feature replaces below-base-consonant glyphs with any
 special forms. Gurmukhi includes three below-base consonant
 forms:
 
-  - "Halant,Ra" (after the base consonant) and "Ra,Halant" (in a
+  - "Halant,Ra" (after the base consonant or syllable base) and "Ra,Halant" (in a
     non-syllable-initial position) take on a below-base form.
-  - "Halant,Ha" (after the base consonant) and "Ha,Halant" (in a
+  - "Halant,Ha" (after the base consonant or syllable base) and "Ha,Halant" (in a
     non-syllable-initial position) take on a below-base form. 
-  - "Halant,Va" (after the base consonant) and "Va,Halant" (in a
+  - "Halant,Va" (after the base consonant or syllable base) and "Va,Halant" (in a
     non-syllable-initial position) take on a below-base form. 
 
 Because Gurmukhi incorporates the `BLWF_MODE_PRE_AND_POST` shaping
@@ -1127,7 +1127,7 @@ characteristic.
 #### 3.9: half ####
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
-base consonant with "half forms" of the consonant glyphs. There are
+base consonant or syllable base with "half forms" of the consonant glyphs. There are
 three exceptions to the default behavior, for which the shaping engine
 must test:
 
@@ -1248,7 +1248,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra positioning](/images/gurmukhi/gurmukhi-matra-position.png)
 
@@ -1257,7 +1257,7 @@ the base consonant, and all half forms.
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Gurmukhi incorporates the `REPH_POS_BEFORE_SUBJOINED`
 shaping characteristic, this final position is immediately after the
-base consonant and before any subjoined (below-base consonant or below-base
+base consonant or syllable base and before any subjoined (below-base consonant or below-base
 dependent vowel) forms.
 
   - If the syllable does not have a base consonant (such as a syllable
@@ -1322,7 +1322,7 @@ above-base marks or contextually appropriate mark-and-base ligatures.
 
 
 The `blws` feature replaces below-base-consonant glyphs with special
-presentation forms. This usually includes replacing base consonants that
+presentation forms. This usually includes replacing base consonant or syllable bases that
 are followed by below-base-consonant forms (like those of "Ra", "Ha",
 "Va", or "Yakash") with contextual ligatures.
 
@@ -1421,7 +1421,7 @@ The old Indic shaping model also did not recognize the
 `BLWF_MODE_PRE_AND_POST` shaping characteristic. Instead, `<guru>`
 was treated as if it followed the `BLWF_MODE_POST_ONLY`
 characteristic. In other words, below-base form substitutions were
-only applied to consonants after the base consonant.
+only applied to consonants after the base consonant or syllable base.
 
 In addition, for some scripts, left-side dependent vowel marks
 (matras) were not repositioned during the final reordering
@@ -1444,7 +1444,7 @@ the `<guru>` script tag and it is known that the font in use supports
 only the `<gur2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant when it is
+below-base consonants occuring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -75,6 +75,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.
@@ -181,12 +186,12 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the syllable base to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -334,7 +339,7 @@ track. These include:
     a specific, implicit sequence.
 	
   - Whether the below-base forms feature is applied only to consonants
-    before the base consonant, only to consonants after the base
+    before the syllable base, only to consonants after the base
     consonant, or to both.
 	
   - The ordering positions for dependent vowels
@@ -386,13 +391,36 @@ begin with either a consonant or an independent vowel.
 
 If the syllable begins with a consonant, then the consonant that
 provides the vowel sound is referred to as the "base" consonant. If
-the syllable begins with an independent vowel, that vowel is the
-syllable's only vowel sound and, by definition, there is no "base"
-consonant. 
+the syllable begins with an independent vowel, that independent vowel
+is the syllable's only vowel sound and serves as the "base". 
 
 > Note: A consonant that is not accompanied by a dependent vowel (matra) sign
 > carries the script's inherent vowel sound. This vowel sound is changed
 > by a dependent vowel (matra) sign following the consonant.
+
+From the shaping engine's perspective, the main distinction between a
+syllable with a base consonant and a syllable with an
+independent-vowel base is that a syllable with an independent-vowel
+base is less likely to include additional consonants in special forms
+and less likely to include depedendent vowel signs
+(matras). Therefore, in the common case, vowel-based syllables may
+involve less reordering, substitution feature applications, and other
+processing than consonant-based syllables.
+
+In some languages and orthographies, vowel-based syllables are
+not permitted to include additional consonants or matras, and certain
+GSUB substitution features do not occur. However, there are often
+known exceptions, and real-world text makes no such guarantees. 
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 Generally speaking, the base consonant is the final consonant of the
 syllable and its vowel sound designates the end of the syllable. This
@@ -507,6 +535,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > identification class, and that the other "combining consonant"
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
+
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -649,7 +683,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -671,19 +705,21 @@ which a codepoint might be reordered, across all of the Indic
 scripts. It includes some ordering categories not utilized in
 Gurmukhi. 
 
-The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
-vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+The basic positions (left to right) are "Reph"
+(`POS_RA_TO_BECOME_REPH`), dependent vowels (matras) and consonants
+positioned before the base consonant or syllable base
+(`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base consonant
+or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
-(`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
-and syllable-modifying or Vedic signs (`POS_SMVD`).
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base
+consonant or syllable base (`POS_POSTBASE_CONSONANT`), syllable-final
+consonants (`POS_FINAL_CONSONANT`), and syllable-modifying or Vedic
+signs (`POS_SMVD`).
 
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -697,7 +733,29 @@ For a definition of the "base" consonant, refer to step 2.1, which follows.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
+
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base, and it should be tagged
+as `POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a standalone sequence or other syllable that begins with a placeholder
+or dotted circle, the placeholder or dotted circle will always serve
+as the syllable base, and it should be tagged as
+`POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a syllable that begins with a consonant, the shaping engine must
+determine the base consonant by a script-specific algorithm.
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 The base consonant is defined as the consonant in a consonant-based
 syllable that carries the syllable's vowel sound. That vowel sound
@@ -705,21 +763,15 @@ will either be provided by the script's inherent vowel (in which case
 it is not written with a separate character) or the sound will be designated
 by the addition of a dependent-vowel (matra) sign.
 
-Vowel-based syllables, standalone-sequences, and broken text runs will
-not have base consonants.
 
-> Note: For consistency with consonant-based syllables, shaping
-> engines may choose to treat the independent vowel of a vowel-based
-> syllable as a "pseudo-base" or surrogate base consonant.
->
-> Because vowel-based syllables will not include consonants and
+<!--- > Because vowel-based syllables will not include consonants and
 > because independent vowels do not take on special forms or require
 > reordering, many of the steps that follow will involve no
 > work for a vowel-based syllable. However, vowel-based syllables must
 > still be sorted and their marks handled correctly, and GSUB and GPOS
 > lookups must be applied. These steps of the shaping process follow
 > the same rules that are employed for consonant-based syllables.
-
+--->
 
 While performing the base-consonant search, shaping engines may
 also encounter special-form consonants, including below-base
@@ -727,7 +779,7 @@ consonants and post-base consonants. Each of these special-form
 consonants must also be tagged (`POS_BELOWBASE_CONSONANT`,
 `POS_POSTBASE_CONSONANT`, respectively). 
 
-Any pre-base-reordering consonant (such as a pre-base-reodering "Ra")
+Any pre-base-reordering consonant (such as a pre-base-reordering "Ra")
 encountered during the base-consonant search must be tagged
 `POS_POSTBASE_CONSONANT`. 
  
@@ -785,12 +837,12 @@ be tagged as `POS_BELOWBASE_CONSONANT`.
 
 > Note: Because Gurmukhi employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search, only the "Halant,_consonant_" 
-> pattern following the base consonant for these below-base forms will
+> pattern following the syllable base for these below-base forms will
 > be encountered. Step 2.5 below ensures that the "_consonant_,Halant"
-> pattern preceding the base consonant for these below-base forms will
+> pattern preceding the syllable base for these below-base forms will
 > also be tagged correctly.
 
 
@@ -850,10 +902,9 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be tagged
-with `POS_PREBASE_CONSONANT`.
-
- Excluding initial "Ra,Halant" sequences that will become "Reph"s:
+Fifth, consonants that occur before the syllable base must be tagged
+with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences
+that will become "Reph"s: 
 
   - If the consonant has a below-base form, tag it as
           `POS_BELOWBASE_CONSONANT`. 
@@ -883,13 +934,13 @@ Gurmukhi includes three below-base consonant forms:
 
 > Note: Because Gurmukhi employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search in 2.1, any instances of the
-> "Halant,_consonant_"  pattern following the base consonant for these
+> "Halant,_consonant_"  pattern following the syllable base for these
 > below-base forms will be encountered. The tagging in this step
-> ensures that the "_consonant_,Halant" pattern preceding the base
-> consonant for these below-base forms will also be tagged correctly.
+> ensures that the "_consonant_,Halant" pattern preceding the syllable
+> base for these below-base forms will also be tagged correctly.
 
 
 #### 2.6: Reph ####
@@ -908,7 +959,7 @@ Sixth, initial "Ra,Halant" sequences that will become "Reph"s must be tagged wit
 #### 2.7: Final consonants ####
 
 Seventh, all final consonants must be tagged. Consonants that occur
-after the base consonant _and_ after a dependent vowel (matra) sign
+after the syllable base _and_ after a dependent vowel (matra) sign
 must be tagged with  `POS_FINAL_CONSONANT`.
 
 > Note: Final consonants occur only in Sinhala and should not be
@@ -929,29 +980,29 @@ Marks in the `BINDU`, `VISARGA`, `AVAGRAHA`, `CANTILLATION`,
 be tagged with `POS_SMVD`. 
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final sort order.
@@ -1145,10 +1196,10 @@ must be applied after the `half` feature.
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -1162,16 +1213,24 @@ because it was almost certainly lost in the preceding GSUB stage.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -1188,8 +1247,8 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
 
 ![Pre-base matra positioning](/images/gurmukhi/gurmukhi-matra-position.png)
 
@@ -1219,7 +1278,7 @@ left of "Halant", to allow for potential matching with `abvs` or
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to immediately before
-the base consonant.
+the base consonant or syllable base.
   
 Gurmukhi does not use pre-base-reordering consonants, so this step will
 involve no work when processing `<gur2>` text. It is included here in order

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -1257,7 +1257,7 @@ the base consonant or syllable base, and all half forms.
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Gurmukhi incorporates the `REPH_POS_BEFORE_SUBJOINED`
 shaping characteristic, this final position is immediately after the
-base consonant or syllable base and before any subjoined (below-base consonant or below-base
+syllable base and before any subjoined (below-base consonant or below-base
 dependent vowel) forms.
 
   - If the syllable does not have a base consonant (such as a syllable

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -332,7 +332,7 @@ syllable are reordered during the shaping process,
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -355,17 +355,17 @@ could reduce an implementation's code size and complexity.
 
 The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
 vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+consonant or syllable base (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
+consonant or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant or syllable base
 (`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
 and syllable-modifying or Vedic signs (`POS_SMVD`).
 
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the base consonant or syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -393,8 +393,8 @@ track. These include:
   - How "Reph" is encoded or requested in a syllable.
 	
   - Whether the below-base forms feature is applied only to consonants
-    after the base consonant, or to consonants before the base
-    consonant and those after the base consonant.
+    after the base consonant or syllable base, or to consonants before the base
+    consonant and those after the base consonant or syllable base.
 	
   - The ordering positions for dependent vowels
     (matras). Specifically, the ordering for left-side, right-side, 
@@ -498,7 +498,7 @@ table:
   - immediately before the first subjoined (below-base) consonant, in
     the ordering position `POS_BEFORE_SUBJOINED`.
 	
-  - immediately after the base consonant, in the ordering position `POS_AFTER_MAIN`.
+  - immediately after the base consonant or syllable base, in the ordering position `POS_AFTER_MAIN`.
 	
   - immediately after the last subjoined (below-base) consonant, in
     the ordering position `POS_AFTER_SUBJOINED`.
@@ -582,10 +582,10 @@ table:
 
 Below-base consonant forms (the `blwf` feature) may be applied:
 
-  - Only to consonants after the base consonant. This is designated
+  - Only to consonants after the base consonant or syllable base. This is designated
     `BLWF_MODE_POST_ONLY`.
 	
-  - To consonants occurring before or after the base consonant. This is
+  - To consonants occurring before or after the base consonant or syllable base. This is
     designated `BLWF_MODE_PRE_AND_POST`.
 
 
@@ -660,7 +660,7 @@ Above-base matras may be positioned:
   - immediately before the first subjoined (below-base) consonant, in
     the ordering position `POS_BEFORE_SUBJOINED`.
 	
-  - immediately after the base consonant, in the ordering position `POS_AFTER_MAIN`.
+  - immediately after the base consonant or syllable base, in the ordering position `POS_AFTER_MAIN`.
 	
   - immediately after the last subjoined (below-base) consonant, in
     the ordering position `POS_AFTER_SUBJOINED`.
@@ -746,8 +746,8 @@ combining with the base consonant (e.g., "_str_", "_pl_") but they
 do not add a vowel sound.
 
 Some Indic scripts also include special consonants that can occur after the
-base consonant. These post-base consonants and final consonants will
-also be separated from the base consonant by a "Halant" mark; the
+base consonant or syllable base. These post-base consonants and final consonants will
+also be separated from the base consonant or syllable base by a "Halant" mark; the
 algorithm for correctly identifying the base consonant includes a test
 to recognize these sequences and not mis-identify the base consonant.
 
@@ -1314,7 +1314,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 #### 4.3: Reph ####
 
@@ -1400,14 +1400,14 @@ The old Indic shaping model also did not recognize the
 `BLWF_MODE_PRE_AND_POST` shaping characteristic. Instead, all scripts
 were treated as if they followed the `BLWF_MODE_POST_ONLY`
 characteristic. In other words, below-base form substitutions were
-only applied to consonants after the base consonant.
+only applied to consonants after the base consonant or syllable base.
 
 In addition, left-side dependent vowel marks
 (matras) were not repositioned during the final reordering
 stage. For `<deva>`, `<beng>`, `<gujr>`, `<guru>`, `<knda>`,
 `<orya>`, and `<telu>` text, the left-side matra was always positioned
 at the beginning of the syllable. For `<mlym>` and `<taml>` text, the
-left-side matra was positioned immediately before the base consonant.
+left-side matra was positioned immediately before the base consonant or syllable base.
 
 
 ### Advice for handling fonts with old Indic features only ###

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -120,6 +120,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.
@@ -219,12 +224,12 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the syllable base to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -837,6 +842,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
 
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
+
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
 > though some of these codepoints (such as `MODIFYING_LETTER`) can
@@ -984,7 +995,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -1011,7 +1022,7 @@ the [sort ordering](#sort-ordering) section of this document.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
 
 The algorithm used to find the base consonant varies according to the
 base-consonant shaping characteristic of the script.
@@ -1126,7 +1137,7 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be tagged
+Fifth, consonants that occur before the syllable base must be tagged
 with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences
 that will become "Reph"s: 
 
@@ -1175,32 +1186,39 @@ Marks in the `BINDU`, `VISARGA`, `AVAGRAHA`, `CANTILLATION`,
 be tagged with `POS_SMVD`. 
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final sort order.
+
+<!--- EXCEPTION: Uniscribe does NOT move a halant with a preceding -->
+<!--left-matra. HarfBuzz follows suit, for compatibility reasons. --->
+
+<!--- HarfBuzz also tags everything between a post-base consonant or -->
+<!--matra and another post-base consonant as belonging to the latter -->
+<!--post-base consonant. --->
 
 
 ### 3: Applying the basic substitution features from GSUB ###
@@ -1244,10 +1262,10 @@ pages for further script-specific information.
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -1261,16 +1279,24 @@ because it was almost certainly lost in the preceding GSUB stage.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -1287,8 +1313,8 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
 
 #### 4.3: Reph ####
 
@@ -1299,7 +1325,7 @@ position. The correct final position depends on the script's
 #### 4.4: Pre-base reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to immediately before
-the base consonant.
+the base consonant or syllable base.
   
 
 #### 4.5: Initial matras ####

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -791,7 +791,7 @@ The algorithm for determining the base consonant is
 > During the base-consonant search, therefore, all of these below-base
 > form sequences will be encountered and tagged correctly as
 > "Halant,_consonant_" patterns. Step 2.5 below exists to ensure that
-> the "_consonant_,Halant" pattern preceding the base consonant or syllable base in
+> the "_consonant_,Halant" pattern preceding the base consonant or syllable base
 > for below-base forms in other Indic scripts will also be tagged correctly.
 
 #### 2.2: Matra decomposition ####
@@ -915,7 +915,7 @@ because it is part of the general processing scheme for shaping Indic scripts.
 > During the base-consonant search in 2.1, therefore, all of these below-base
 > form sequences will be encountered and tagged correctly as
 > "Halant,_consonant_" patterns. The tagging is this step ensures that
-> the "_consonant_,Halant" pattern preceding the base consonant or syllable base in
+> the "_consonant_,Halant" pattern preceding the base consonant or syllable base
 > for below-base forms in other Indic scripts will also be tagged correctly.
 
 #### 2.6: Reph ####

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -78,6 +78,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.
@@ -88,7 +93,7 @@ Shaping Kannada text depends on the shaping engine correctly
 classifying each glyph in the run. As with most other scripts, the
 classifications must distinguish between consonants, vowels
 (independent and dependent), numerals, punctuation, and various types
-of diacritical mark. 
+of diacritical mark.
 
 For most codepoints, the `General Category` property defined in the Unicode
 standard is correct, but it is not sufficient to fully capture the
@@ -162,12 +167,12 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the syllable base to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -310,7 +315,7 @@ track. These include:
     a specific, implicit sequence.
 	
   - Whether the below-base forms feature is applied only to consonants
-    before the base consonant, only to consonants after the base
+    before the syllable base, only to consonants after the base
     consonant, or to both.
 	
   - The ordering positions for dependent vowels
@@ -385,9 +390,8 @@ begin with either a consonant or an independent vowel.
 
 If the syllable begins with a consonant, then the consonant that
 provides the vowel sound is referred to as the "base" consonant. If
-the syllable begins with an independent vowel, that vowel is the
-syllable's only vowel sound and, by definition, there is no "base"
-consonant. 
+the syllable begins with an independent vowel, that independent vowel
+is the syllable's only vowel sound and serves as the "base". 
 
 > Note: A consonant that is not accompanied by a dependent vowel (matra) sign
 > carries the script's inherent vowel sound. This vowel sound is changed
@@ -492,6 +496,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > identification class, and that the other "combining consonant"
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
+
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -633,7 +643,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -655,19 +665,21 @@ which a codepoint might be reordered, across all of the Indic
 scripts. It includes some ordering categories not utilized in
 Kannada. 
 
-The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
-vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+The basic positions (left to right) are "Reph"
+(`POS_RA_TO_BECOME_REPH`), dependent vowels (matras) and consonants
+positioned before the base consonant or syllable base
+(`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base consonant
+or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
-(`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
-and syllable-modifying or Vedic signs (`POS_SMVD`).
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base
+consonant or syllable base (`POS_POSTBASE_CONSONANT`), syllable-final
+consonants (`POS_FINAL_CONSONANT`), and syllable-modifying or Vedic
+signs (`POS_SMVD`).
 
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -681,7 +693,29 @@ For a definition of the "base" consonant, refer to step 2.1, which follows.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
+
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base, and it should be tagged
+as `POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a standalone sequence or other syllable that begins with a placeholder
+or dotted circle, the placeholder or dotted circle will always serve
+as the syllable base, and it should be tagged as
+`POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a syllable that begins with a consonant, the shaping engine must
+determine the base consonant by a script-specific algorithm.
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 The base consonant is defined as the consonant in a consonant-based
 syllable that carries the syllable's vowel sound. That vowel sound
@@ -689,21 +723,15 @@ will either be provided by the script's inherent vowel (in which case
 it is not written with a separate character) or the sound will be designated
 by the addition of a dependent-vowel (matra) sign.
 
-Vowel-based syllables, standalone-sequences, and broken text runs will
-not have base consonants.
 
-> Note: For consistency with consonant-based syllables, shaping
-> engines may choose to treat the independent vowel of a vowel-based
-> syllable as a "pseudo-base" or surrogate base consonant.
->
-> Because vowel-based syllables will not include consonants and
+<!--- > Because vowel-based syllables will not include consonants and
 > because independent vowels do not take on special forms or require
 > reordering, many of the steps that follow will involve no
 > work for a vowel-based syllable. However, vowel-based syllables must
 > still be sorted and their marks handled correctly, and GSUB and GPOS
 > lookups must be applied. These steps of the shaping process follow
 > the same rules that are employed for consonant-based syllables.
-
+--->
 
 While performing the base-consonant search, shaping engines may
 also encounter special-form consonants, including below-base
@@ -711,7 +739,7 @@ consonants and post-base consonants. Each of these special-form
 consonants must also be tagged (`POS_BELOWBASE_CONSONANT`,
 `POS_POSTBASE_CONSONANT`, respectively). 
 
-Any pre-base-reordering consonant (such as a pre-base-reodering "Ra")
+Any pre-base-reordering consonant (such as a pre-base-reordering "Ra")
 encountered during the base-consonant search must be tagged
 `POS_POSTBASE_CONSONANT`. 
  
@@ -856,7 +884,7 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be tagged
+Fifth, consonants that occur before the syllable base must be tagged
 with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences
 that will become "Reph"s: 
 
@@ -901,14 +929,14 @@ Sixth, initial "Ra,Halant" sequences that will become "Reph"s must be tagged wit
 #### 2.7: Final consonants ####
 
 Seventh, all final consonants must be tagged. Consonants that occur
-after the base consonant _and_ after a dependent vowel (matra) sign
+after the syllable base _and_ after a dependent vowel (matra) sign
 must be tagged with  `POS_FINAL_CONSONANT`.
 
 > Note: Final consonants occur only in Sinhala and should not be
 > expected in `<knd2>` text runs. This step is included here to
 > maintain compatibility across Indic scripts.
 
-	
+
 #### 2.8: Mark tagging ####
 
 Eighth, all marks must be tagged. 
@@ -922,32 +950,39 @@ Marks in the `BINDU`, `VISARGA`, `AVAGRAHA`, `CANTILLATION`,
 be tagged with `POS_SMVD`. 
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final sort order.
+
+<!--- EXCEPTION: Uniscribe does NOT move a halant with a preceding -->
+<!--left-matra. HarfBuzz follows suit, for compatibility reasons. --->
+
+<!--- HarfBuzz also tags everything between a post-base consonant or -->
+<!--matra and another post-base consonant as belonging to the latter -->
+<!--post-base consonant. --->
 
 
 ### 3: Applying the basic substitution features from GSUB ###
@@ -1051,9 +1086,9 @@ form.
 #### 3.9: half ####
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
-base consonant with "half forms" of the consonant glyphs. There are
-three exceptions to the default behavior, for which the shaping engine
-must test:
+base consonant or syllable base with "half forms" of the consonant
+glyphs. There arethree exceptions to the default behavior, for which
+the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been tagged for
     the `rphf` feature earlier, must not be tagged for potential
@@ -1106,10 +1141,10 @@ must be applied after the `half` feature.
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -1123,16 +1158,24 @@ because it was almost certainly lost in the preceding GSUB stage.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -1149,8 +1192,8 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
 
 Kannada does not use pre-base matras, so this step will
 involve no work when processing `<knd2>` text. It is included here in
@@ -1183,7 +1226,7 @@ left of "Halant", to allow for potential matching with `abvs` or
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to immediately before
-the base consonant.
+the base consonant or syllable base.
   
 Kannada does not use pre-base-reordering consonants, so this step will
 involve no work when processing `<knd2>` text. It is included here in order

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -786,12 +786,12 @@ The algorithm for determining the base consonant is
 
 > Note: Because Kannada employs the `BLWF_MODE_POST_ONLY` shaping
 > characteristic, consonants with below-base special forms will occur
-> only after the base consonant. 
+> only after the base consonant or syllable base. 
 > 
 > During the base-consonant search, therefore, all of these below-base
 > form sequences will be encountered and tagged correctly as
 > "Halant,_consonant_" patterns. Step 2.5 below exists to ensure that
-> the "_consonant_,Halant" pattern preceding the base consonant in
+> the "_consonant_,Halant" pattern preceding the base consonant or syllable base in
 > for below-base forms in other Indic scripts will also be tagged correctly.
 
 #### 2.2: Matra decomposition ####
@@ -910,12 +910,12 @@ because it is part of the general processing scheme for shaping Indic scripts.
 
 > Note: Because Kannada employs the `BLWF_MODE_POST_ONLY` shaping
 > characteristic, consonants with below-base special forms will occur
-> only after the base consonant. 
+> only after the base consonant or syllable base. 
 > 
 > During the base-consonant search in 2.1, therefore, all of these below-base
 > form sequences will be encountered and tagged correctly as
 > "Halant,_consonant_" patterns. The tagging is this step ensures that
-> the "_consonant_,Halant" pattern preceding the base consonant in
+> the "_consonant_,Halant" pattern preceding the base consonant or syllable base in
 > for below-base forms in other Indic scripts will also be tagged correctly.
 
 #### 2.6: Reph ####
@@ -1193,7 +1193,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 Kannada does not use pre-base matras, so this step will
 involve no work when processing `<knd2>` text. It is included here in

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -1262,7 +1262,7 @@ the base consonant or syllable base, and all half forms.
 "Reph" or "Repha" must be moved from the beginning of the syllable to its final
 position. Because Malayalam incorporates the `REPH_POS_AFTER_MAIN`
 shaping characteristic, this final position is immediately after the
-base consonant or syllable base.
+syllable base.
 
   - If the syllable does not have a base consonant (such as a syllable
     based on an independent vowel), then the final "Reph" position is

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -432,7 +432,7 @@ combining with the base consonant (e.g., "_thr_" or "_spl_").
 
 Three consonants in Malayalam are allowed to occur in post-base
 position: "Ya", "Va", and "Ra". The post-base "Ra" is reordered to
-before the base consonant during the final-reordering stage of the
+before the base consonant or syllable base during the final-reordering stage of the
 shaping process. The post-base forms of "Ya" and "Va"
 remain in post-base position.
 
@@ -703,10 +703,10 @@ Malayalam.
 
 The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
 vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+consonant or syllable base (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
+consonant or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant or syllable base
 (`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
 and syllable-modifying or Vedic signs (`POS_SMVD`).
 
@@ -808,7 +808,7 @@ The algorithm for determining the base consonant is
   - The consonant stopped at will be the base consonant.
 
 Malayalam includes a pre-base-reordering "Ra".  A "Halant,Ra" sequence
-after the base consonant will be reordered to a pre-base position
+after the base consonant or syllable base will be reordered to a pre-base position
 during the final-reordering stage.
 
 Malayalam includes two consonants that can take on
@@ -821,8 +821,8 @@ post-base form: "Ya" and Va".
 
 Malayalam includes one consonant that can take on a below-base form:
 
-  - "Halant,La" (after the base consonant) and "La,Halant" (before the
-    base consonant) take on a below-base form.
+  - "Halant,La" (after the base consonant or syllable base) and "La,Halant" (before the
+    base consonant or syllable base) take on a below-base form.
 
 > Note: Because Malayalam employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
@@ -919,8 +919,8 @@ that will become "Reph"s:
 
 Malayalam includes one consonant that can take on a below-base form:
 
-  - "Halant,La" (after the base consonant) and "La,Halant" (before the
-    base consonant) take on a below-base form.
+  - "Halant,La" (after the base consonant or syllable base) and "La,Halant" (before the
+    base consonant or syllable base) take on a below-base form.
 
 > Note: Because Malayalam employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
@@ -1253,7 +1253,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 ![Matra positioning](/images/malayalam/malayalam-matra-position.png)
 
@@ -1296,7 +1296,7 @@ The algorithm for reordering "Ra" in this circumstance is:
   - Select the final position using [the same method](#42-pre-base-matras) as used for
     reordering a pre-base matra.
   - If the pre-base matra positioning algorithm cannot determine the final
-    position, place the "Ra" immediately before the base consonant.
+    position, place the "Ra" immediately before the base consonant or syllable base.
 
 ![Pre-base-reordering consonant positioning](/images/malayalam/malayalam-pref-position.png)
 
@@ -1337,7 +1337,8 @@ presentation forms. This usually includes contextual variants of
 above-base marks or contextually appropriate mark-and-base ligatures.
 
 The `blws` feature replaces below-base-consonant glyphs with special
-presentation forms. This usually includes replacing base consonants that
+presentation forms. This usually includes replacing base consonants or
+syllable bases that
 are adjacent to the below-base-consonant form of "La" with contextual ligatures.
 
 The `psts` feature replaces post-base-consonant glyphs with special
@@ -1436,7 +1437,7 @@ The old Indic shaping model also did not recognize the
 `BLWF_MODE_PRE_AND_POST` shaping characteristic. Instead, `<mlym>`
 was treated as if it followed the `BLWF_MODE_POST_ONLY`
 characteristic. In other words, below-base form substitutions were
-only applied to consonants after the base consonant.
+only applied to consonants after the base consonant or syllable base.
 
 In addition, for some scripts, left-side dependent vowel marks
 (matras) were not repositioned during the final reordering
@@ -1460,7 +1461,7 @@ the `<mlym>` script tag and it is known that the font in use supports
 only the `<mlm2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant when it is
+below-base consonants occuring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -71,6 +71,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.
@@ -160,12 +165,12 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the syllable base to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -318,7 +323,7 @@ track. These include:
     a specific, implicit sequence.
 	
   - Whether the below-base forms feature is applied only to consonants
-    before the base consonant, only to consonants after the base
+    before the syllable base, only to consonants after the base
     consonant, or to both.
 	
   - The ordering positions for dependent vowels
@@ -333,7 +338,7 @@ characteristics include:
   - `BASE_POS_LAST` = The base consonant of a syllable is the last
      consonant, not counting any special final-consonant forms.
 
-  - `REPH_POS_AFTER_MAIN` = "Reph" is ordered after the base consonant.
+  - `REPH_POS_AFTER_MAIN` = "Reph" is ordered after the sylable base.
 
   - `REPH_MODE_LOGICAL_REPHA` = "Reph" is encoded as its own Unicode
      codepoint ("Repha"), but it must still be reordered. 
@@ -374,13 +379,36 @@ begin with either a consonant or an independent vowel.
 
 If the syllable begins with a consonant, then the consonant that
 provides the vowel sound is referred to as the "base" consonant. If
-the syllable begins with an independent vowel, that vowel is the
-syllable's only vowel sound and, by definition, there is no "base"
-consonant. 
+the syllable begins with an independent vowel, that independent vowel
+is the syllable's only vowel sound and serves as the "base". 
 
 > Note: A consonant that is not accompanied by a dependent vowel (matra) sign
 > carries the script's inherent vowel sound. This vowel sound is changed
 > by a dependent vowel (matra) sign following the consonant.
+
+From the shaping engine's perspective, the main distinction between a
+syllable with a base consonant and a syllable with an
+independent-vowel base is that a syllable with an independent-vowel
+base is less likely to include additional consonants in special forms
+and less likely to include depedendent vowel signs
+(matras). Therefore, in the common case, vowel-based syllables may
+involve less reordering, substitution feature applications, and other
+processing than consonant-based syllables.
+
+In some languages and orthographies, vowel-based syllables are
+not permitted to include additional consonants or matras, and certain
+GSUB substitution features do not occur. However, there are often
+known exceptions, and real-world text makes no such guarantees. 
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 Generally speaking, the base consonant is the final consonant of the
 syllable and its vowel sound designates the end of the syllable. This
@@ -503,6 +531,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > identification class, and that the other "combining consonant"
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
+
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -645,7 +679,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -679,7 +713,7 @@ and syllable-modifying or Vedic signs (`POS_SMVD`).
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -693,7 +727,29 @@ For a definition of the "base" consonant, refer to step 2.1, which follows.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
+
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base, and it should be tagged
+as `POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a standalone sequence or other syllable that begins with a placeholder
+or dotted circle, the placeholder or dotted circle will always serve
+as the syllable base, and it should be tagged as
+`POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a syllable that begins with a consonant, the shaping engine must
+determine the base consonant by a script-specific algorithm.
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 The base consonant is defined as the consonant in a consonant-based
 syllable that carries the syllable's vowel sound. That vowel sound
@@ -701,21 +757,15 @@ will either be provided by the script's inherent vowel (in which case
 it is not written with a separate character) or the sound will be designated
 by the addition of a dependent-vowel (matra) sign.
 
-Vowel-based syllables, standalone-sequences, and broken text runs will
-not have base consonants.
 
-> Note: For consistency with consonant-based syllables, shaping
-> engines may choose to treat the independent vowel of a vowel-based
-> syllable as a "pseudo-base" or surrogate base consonant.
->
-> Because vowel-based syllables will not include consonants and
+<!--- > Because vowel-based syllables will not include consonants and
 > because independent vowels do not take on special forms or require
 > reordering, many of the steps that follow will involve no
 > work for a vowel-based syllable. However, vowel-based syllables must
 > still be sorted and their marks handled correctly, and GSUB and GPOS
 > lookups must be applied. These steps of the shaping process follow
 > the same rules that are employed for consonant-based syllables.
-
+--->
 
 While performing the base-consonant search, shaping engines may
 also encounter special-form consonants, including below-base
@@ -723,7 +773,7 @@ consonants and post-base consonants. Each of these special-form
 consonants must also be tagged (`POS_BELOWBASE_CONSONANT`,
 `POS_POSTBASE_CONSONANT`, respectively). 
 
-Any pre-base-reordering consonant (such as a pre-base-reodering "Ra")
+Any pre-base-reordering consonant (such as a pre-base-reordering "Ra")
 encountered during the base-consonant search must be tagged
 `POS_POSTBASE_CONSONANT`. 
  
@@ -776,12 +826,12 @@ Malayalam includes one consonant that can take on a below-base form:
 
 > Note: Because Malayalam employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search, only the "Halant,_consonant_" 
-> pattern following the base consonant for these below-base forms will
+> pattern following the syllable base for these below-base forms will
 > be encountered. Step 2.5 below ensures that the "_consonant_,Halant"
-> pattern preceding the base consonant for these below-base forms will
+> pattern preceding the syllable base for these below-base forms will
 > also be tagged correctly.
 
 
@@ -846,8 +896,9 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be tagged
-with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences that will become "Reph"s:
+Fifth, consonants that occur before the syllable base must be tagged
+with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences
+that will become "Reph"s: 
 
   - If the consonant has a below-base form, tag it as
           `POS_BELOWBASE_CONSONANT`. 
@@ -873,14 +924,13 @@ Malayalam includes one consonant that can take on a below-base form:
 
 > Note: Because Malayalam employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search in 2.1, any instances of the
-> "Halant,_consonant_"  pattern following the base consonant for these
+> "Halant,_consonant_"  pattern following the syllable base for these
 > below-base forms will be encountered. The tagging in this step
-> ensures that the "_consonant_,Halant" pattern preceding the base
-> consonant for these below-base forms will also be tagged correctly.
-
+> ensures that the "_consonant_,Halant" pattern preceding the syllable
+> base for these below-base forms will also be tagged correctly.
 
 
 #### 2.6: Reph ####
@@ -896,7 +946,7 @@ Sixth, initial "Ra,Halant" sequences that will become "Reph"s must be tagged wit
 #### 2.7: Final consonants ####
 
 Seventh, all final consonants must be tagged. Consonants that occur
-after the base consonant _and_ after a dependent vowel (matra) sign
+after the syllable base _and_ after a dependent vowel (matra) sign
 must be tagged with  `POS_FINAL_CONSONANT`.
 
 > Note: Final consonants occur only in Sinhala and should not be
@@ -918,32 +968,39 @@ Marks in the `BINDU`, `VISARGA`, `AVAGRAHA`, `CANTILLATION`,
 be tagged with `POS_SMVD`. 
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final sort order.
+
+<!--- EXCEPTION: Uniscribe does NOT move a halant with a preceding -->
+<!--left-matra. HarfBuzz follows suit, for compatibility reasons. --->
+
+<!--- HarfBuzz also tags everything between a post-base consonant or -->
+<!--matra and another post-base consonant as belonging to the latter -->
+<!--post-base consonant. --->
 
 
 ### 3: Applying the basic substitution features from GSUB ###
@@ -1074,9 +1131,9 @@ characteristic.
 #### 3.9: half ####
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
-base consonant with "half forms" of the consonant glyphs. There are
-three exceptions to the default behavior, for which the shaping engine
-must test:
+base consonant or syllable base with "half forms" of the consonant
+glyphs. There are three exceptions to the default behavior, for which
+the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been tagged for
     the `rphf` feature earlier, must not be tagged for potential
@@ -1144,10 +1201,10 @@ must be applied after the `half` feature.
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -1161,16 +1218,24 @@ because it was almost certainly lost in the preceding GSUB stage.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -1187,8 +1252,8 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
 
 ![Matra positioning](/images/malayalam/malayalam-matra-position.png)
 
@@ -1197,7 +1262,7 @@ consonant, and all half forms.
 "Reph" or "Repha" must be moved from the beginning of the syllable to its final
 position. Because Malayalam incorporates the `REPH_POS_AFTER_MAIN`
 shaping characteristic, this final position is immediately after the
-base consonant.
+base consonant or syllable base.
 
   - If the syllable does not have a base consonant (such as a syllable
     based on an independent vowel), then the final "Reph" position is
@@ -1219,7 +1284,7 @@ left of "Halant", to allow for potential matching with `abvs` or
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to before
-the base consonant.
+the base consonant or syllable base.
 
 Malayalam includes one such reordering consonant. "Ra" occurring in the
 post-base position is reordered to a pre-base position at this step.
@@ -1376,7 +1441,7 @@ only applied to consonants after the base consonant.
 In addition, for some scripts, left-side dependent vowel marks
 (matras) were not repositioned during the final reordering
 stage. For `<mlym>` text, the left-side matra was always positioned
-immediately before the base consonant.
+immediately before the base consonant or syllable base.
 
 
 ### Advice for handling fonts with `<mlym>` features only ###

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -310,7 +310,7 @@ characteristics include:
      consonant, not counting any special final-consonant forms.
 
   - `REPH_POS_AFTER_MAIN` = "Reph" is ordered immediately after the
-     base consonant.
+     base consonant or syllable base.
 
   - `REPH_MODE_IMPLICIT` = "Reph" is formed by an initial "Ra,Halant" sequence.
 
@@ -318,7 +318,7 @@ characteristics include:
      pre-base consonants and to post-base consonants.
 
   - `MATRA_POS_TOP` = `POS_AFTER_MAIN`  = Above-base matras are
-    ordered immediately after the base consonant.
+    ordered immediately after the base consonant or syllable base.
 
   - `MATRA_POS_RIGHT` = `POS_AFTER_POST` = Right-side matras are
      ordered after all post-base consonant forms.
@@ -1245,7 +1245,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra position](/images/oriya/oriya-matra-position.png)
 
@@ -1255,7 +1255,7 @@ the base consonant, and all half forms.
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Oriya incorporates the `REPH_POS_AFTER_MAIN`
 shaping characteristic, this final position is immediately after the
-base consonant.
+base consonant or syllable base.
 
   - If the syllable does not have a base consonant (such as a syllable
     based on an independent vowel), then the final "Reph" position is
@@ -1328,7 +1328,8 @@ above-base marks or contextually appropriate mark-and-base ligatures.
 
 
 The `blws` feature replaces below-base-consonant glyphs with special
-presentation forms. This usually includes replacing base consonants that
+presentation forms. This usually includes replacing base consonants or
+syllable bases that
 are adjacent to below-base-consonant forms like "Raphala" with
 contextual ligatures.
 
@@ -1430,7 +1431,7 @@ The old Indic shaping model also did not recognize the
 `BLWF_MODE_PRE_AND_POST` shaping characteristic. Instead, `<orya>`
 was treated as if it followed the `BLWF_MODE_POST_ONLY`
 characteristic. In other words, below-base form substitutions were
-only applied to consonants after the base consonant.
+only applied to consonants after the base consonant or syllable base.
 
 In addition, for some scripts, left-side dependent vowel marks
 (matras) were not repositioned during the final reordering
@@ -1453,7 +1454,7 @@ the `<orya>` script tag and it is known that the font in use supports
 only the `<ory2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant when it is
+below-base consonants occuring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -70,6 +70,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.
@@ -80,7 +85,7 @@ Shaping Oriya text depends on the shaping engine correctly
 classifying each glyph in the run. As with most other scripts, the
 classifications must distinguish between consonants, vowels
 (independent and dependent), numerals, punctuation, and various types
-of diacritical mark. 
+of diacritical mark.
 
 For most codepoints, the `General Category` property defined in the Unicode
 standard is correct, but it is not sufficient to fully capture the
@@ -141,12 +146,12 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the syllable base to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -289,7 +294,7 @@ track. These include:
     a specific, implicit sequence.
 	
   - Whether the below-base forms feature is applied only to consonants
-    before the base consonant, only to consonants after the base
+    before the syllable base, only to consonants after the base
     consonant, or to both.
 	
   - The ordering positions for dependent vowels
@@ -349,6 +354,30 @@ consonant.
 > Note: A consonant that is not accompanied by a dependent vowel (matra) sign
 > carries the script's inherent vowel sound. This vowel sound is changed
 > by a dependent vowel (matra) sign following the consonant.
+
+From the shaping engine's perspective, the main distinction between a
+syllable with a base consonant and a syllable with an
+independent-vowel base is that a syllable with an independent-vowel
+base is less likely to include additional consonants in special forms
+and less likely to include depedendent vowel signs
+(matras). Therefore, in the common case, vowel-based syllables may
+involve less reordering, substitution feature applications, and other
+processing than consonant-based syllables.
+
+In some languages and orthographies, vowel-based syllables are
+not permitted to include additional consonants or matras, and certain
+GSUB substitution features do not occur. However, there are often
+known exceptions, and real-world text makes no such guarantees. 
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 Generally speaking, the base consonant is the final consonant of the
 syllable and its vowel sound designates the end of the syllable. This
@@ -507,6 +536,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
 
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
+
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
 > though some of these codepoints (such as `MODIFYING_LETTER`) can
@@ -647,7 +682,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -669,19 +704,21 @@ which a codepoint might be reordered, across all of the Indic
 scripts. It includes some ordering categories not utilized in
 Oriya. 
 
-The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
-vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+The basic positions (left to right) are "Reph"
+(`POS_RA_TO_BECOME_REPH`), dependent vowels (matras) and consonants
+positioned before the base consonant or syllable base
+(`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base consonant
+or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
-(`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
-and syllable-modifying or Vedic signs (`POS_SMVD`).
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base
+consonant or syllable base (`POS_POSTBASE_CONSONANT`), syllable-final
+consonants (`POS_FINAL_CONSONANT`), and syllable-modifying or Vedic
+signs (`POS_SMVD`).
 
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -695,7 +732,29 @@ For a definition of the "base" consonant, refer to step 2.1, which follows.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
+
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base, and it should be tagged
+as `POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a standalone sequence or other syllable that begins with a placeholder
+or dotted circle, the placeholder or dotted circle will always serve
+as the syllable base, and it should be tagged as
+`POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a syllable that begins with a consonant, the shaping engine must
+determine the base consonant by a script-specific algorithm.
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 The base consonant is defined as the consonant in a consonant-based
 syllable that carries the syllable's vowel sound. That vowel sound
@@ -703,21 +762,15 @@ will either be provided by the script's inherent vowel (in which case
 it is not written with a separate character) or the sound will be designated
 by the addition of a dependent-vowel (matra) sign.
 
-Vowel-based syllables, standalone sequences, and broken text runs will
-not have base consonants.
 
-> Note: For consistency with consonant-based syllables, shaping
-> engines may choose to treat the independent vowel of a vowel-based
-> syllable as a "pseudo-base" or surrogate base consonant.
->
-> Because vowel-based syllables will not include consonants and
+<!--- > Because vowel-based syllables will not include consonants and
 > because independent vowels do not take on special forms or require
 > reordering, many of the steps that follow will involve no
 > work for a vowel-based syllable. However, vowel-based syllables must
 > still be sorted and their marks handled correctly, and GSUB and GPOS
 > lookups must be applied. These steps of the shaping process follow
 > the same rules that are employed for consonant-based syllables.
-
+--->
 
 While performing the base-consonant search, shaping engines may
 also encounter special-form consonants, including below-base
@@ -725,7 +778,7 @@ consonants and post-base consonants. Each of these special-form
 consonants must also be tagged (`POS_BELOWBASE_CONSONANT`,
 `POS_POSTBASE_CONSONANT`, respectively). 
 
-Any pre-base-reordering consonant (such as a pre-base-reodering "Ra")
+Any pre-base-reordering consonant (such as a pre-base-reordering "Ra")
 encountered during the base-consonant search must be tagged
 `POS_POSTBASE_CONSONANT`. 
  
@@ -780,12 +833,12 @@ Oriya includes one consonant that can take on a special below-base form:
 
 > Note: Because Oriya employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search, only the "Halant,_consonant_" 
-> pattern following the base consonant for these below-base forms will
+> pattern following the syllable base for these below-base forms will
 > be encountered. Step 2.5 below ensures that the "_consonant_,Halant"
-> pattern preceding the base consonant for these below-base forms will
+> pattern preceding the syllable base for these below-base forms will
 > also be tagged correctly.
 
 
@@ -867,8 +920,9 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be tagged
-with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences that will become "Reph"s:
+Fifth, consonants that occur before the syllable base must be tagged
+with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences
+that will become "Reph"s: 
 
   - If the consonant has a below-base form, tag it as
           `POS_BELOWBASE_CONSONANT`. 
@@ -896,13 +950,13 @@ Oriya includes one consonant that can take on a special below-base form:
 
 > Note: Because Oriya employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search in 2.1, any instances of the
-> "Halant,_consonant_"  pattern following the base consonant for these
+> "Halant,_consonant_"  pattern following the syllable base for these
 > below-base forms will be encountered. The tagging in this step
-> ensures that the "_consonant_,Halant" pattern preceding the base
-> consonant for these below-base forms will also be tagged correctly.
+> ensures that the "_consonant_,Halant" pattern preceding the syllable
+> base for these below-base forms will also be tagged correctly.
 
 
 #### 2.6: Reph ####
@@ -916,14 +970,14 @@ Sixth, initial "Ra,Halant" sequences that will become "Reph"s must be tagged wit
 #### 2.7: Final consonants ####
 
 Seventh, all final consonants must be tagged. Consonants that occur
-after the base consonant _and_ after a dependent vowel (matra) sign
+after the syllable base _and_ after a dependent vowel (matra) sign
 must be tagged with  `POS_FINAL_CONSONANT`.
 
 > Note: Final consonants occur only in Sinhala and should not be
 > expected in `<ory2>` text runs. This step is included here to
 > maintain compatibility across Indic scripts.
-	
-	
+
+
 #### 2.8: Mark tagging ####
 
 Eighth, all marks must be tagged. 
@@ -940,32 +994,39 @@ Oriya includes one exception to the above general rule. The
 "Candrabindu" (`U+0B01`) must be tagged with `POS_BEFORE_SUBJOINED`.
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final sort order.
+
+<!--- EXCEPTION: Uniscribe does NOT move a halant with a preceding -->
+<!--left-matra. HarfBuzz follows suit, for compatibility reasons. --->
+
+<!--- HarfBuzz also tags everything between a post-base consonant or -->
+<!--matra and another post-base consonant as belonging to the latter -->
+<!--post-base consonant. --->
 
 
 ### 3: Applying the basic substitution features from GSUB ###
@@ -1078,9 +1139,9 @@ characteristic.
 #### 3.9: half ####
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
-base consonant with "half forms" of the consonant glyphs. There are
-three exceptions to the default behavior, for which the shaping engine
-must test:
+base consonant or syllable base with "half forms" of the consonant
+glyphs. There are three exceptions to the default behavior, for which
+the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been tagged for
     the `rphf` feature earlier, must not be tagged for potential
@@ -1132,10 +1193,10 @@ must be applied after the `half` feature.
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -1149,16 +1210,24 @@ because it was almost certainly lost in the preceding GSUB stage.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -1175,8 +1244,8 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
 
 ![Pre-base matra position](/images/oriya/oriya-matra-position.png)
 
@@ -1209,7 +1278,7 @@ left of "Halant", to allow for potential matching with `abvs` or
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to immediately before
-the base consonant.
+the base consonant or syllable base.
   
 Oriya does not use pre-base-reordering consonants, so this step will
 involve no work when processing `<ory2>` text. It is included here in order

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -1255,7 +1255,7 @@ the base consonant or syllable base, and all half forms.
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Oriya incorporates the `REPH_POS_AFTER_MAIN`
 shaping characteristic, this final position is immediately after the
-base consonant or syllable base.
+syllable base.
 
   - If the syllable does not have a base consonant (such as a syllable
     based on an independent vowel), then the final "Reph" position is

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -61,6 +61,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example. In the Sinhalese language, the Reph form is known as _repaya_.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.
@@ -132,12 +137,12 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the syllable base to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -277,7 +282,7 @@ track. These include:
     a specific, implicit sequence.
 	
   - Whether the below-base forms feature is applied only to consonants
-    before the base consonant, only to consonants after the base
+    before the syllable base, only to consonants after the base
     consonant, or to both.
 	
   - The ordering positions for dependent vowels
@@ -330,13 +335,36 @@ begin with either a consonant or an independent vowel.
 
 If the syllable begins with a consonant, then the consonant that
 provides the vowel sound is referred to as the "base" consonant. If
-the syllable begins with an independent vowel, that vowel is the
-syllable's only vowel sound and, by definition, there is no "base"
-consonant. 
+the syllable begins with an independent vowel, that independent vowel
+is the syllable's only vowel sound and serves as the "base". 
 
 > Note: A consonant that is not accompanied by a dependent vowel (matra) sign
 > carries the script's inherent vowel sound. This vowel sound is changed
 > by a dependent vowel (matra) sign following the consonant.
+
+From the shaping engine's perspective, the main distinction between a
+syllable with a base consonant and a syllable with an
+independent-vowel base is that a syllable with an independent-vowel
+base is less likely to include additional consonants in special forms
+and less likely to include depedendent vowel signs
+(matras). Therefore, in the common case, vowel-based syllables may
+involve less reordering, substitution feature applications, and other
+processing than consonant-based syllables.
+
+In some languages and orthographies, vowel-based syllables are
+not permitted to include additional consonants or matras, and certain
+GSUB substitution features do not occur. However, there are often
+known exceptions, and real-world text makes no such guarantees. 
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 Generally speaking, the base consonant is the final consonant of the
 syllable that does not take on a subjoined form, and its vowel sound
@@ -427,6 +455,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > identification class, and that the other "combining consonant"
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
+
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -569,7 +603,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -591,19 +625,21 @@ which a codepoint might be reordered, across all of the Indic
 scripts. It includes some ordering categories not utilized in
 Sinhala. 
 
-The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
-vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+The basic positions (left to right) are "Reph"
+(`POS_RA_TO_BECOME_REPH`), dependent vowels (matras) and consonants
+positioned before the base consonant or syllable base
+(`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base consonant
+or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
-(`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
-and syllable-modifying or Vedic signs (`POS_SMVD`).
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base
+consonant or syllable base (`POS_POSTBASE_CONSONANT`), syllable-final
+consonants (`POS_FINAL_CONSONANT`), and syllable-modifying or Vedic
+signs (`POS_SMVD`).
 
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -617,16 +653,35 @@ For a definition of the "base" consonant, refer to step 2.1, which follows.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
+
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base, and it should be tagged
+as `POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a standalone sequence or other syllable that begins with a placeholder
+or dotted circle, the placeholder or dotted circle will always serve
+as the syllable base, and it should be tagged as
+`POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a syllable that begins with a consonant, the shaping engine must
+determine the base consonant by a script-specific algorithm.
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 The base consonant is defined as the consonant in a consonant-based
 syllable that carries the syllable's vowel sound. That vowel sound
 will either be provided by the script's inherent vowel (in which case
 it is not written with a separate character) or the sound will be designated
 by the addition of a dependent-vowel (matra) sign.
-
-Vowel-based syllables, standalone-sequences, and broken text runs will
-not have base consonants.
 
 Due to the different usage of ZWJ characters in `<sinh>` text runs, a
 different algorithm is required for the shaper to identify the base
@@ -770,32 +825,39 @@ Marks in the `BINDU`, `VISARGA`, `AVAGRAHA`, `CANTILLATION`,
 be tagged with `POS_SMVD`. 
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final sort order.
+
+<!--- EXCEPTION: Uniscribe does NOT move a halant with a preceding -->
+<!--left-matra. HarfBuzz follows suit, for compatibility reasons. --->
+
+<!--- HarfBuzz also tags everything between a post-base consonant or -->
+<!--matra and another post-base consonant as belonging to the latter -->
+<!--post-base consonant. --->
 
 
 ### 3: Applying the basic substitution features from GSUB ###
@@ -948,10 +1010,10 @@ ligatures using the subjoined forms of "Ra" or "Ya".
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -960,16 +1022,24 @@ occur on a per-syllable basis.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -986,8 +1056,8 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
 
 ![Pre-base matra positioning](/images/sinhala/sinhala-matra-position.png)
 
@@ -1004,7 +1074,7 @@ base consonant.
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to immediately before
-the base consonant.
+the base consonant or syllable base.
 
 Sinhala does not use pre-base-reordering consonants, so this step will
 involve no work when processing `<sinh>` text. It is included here in order

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -1066,7 +1066,7 @@ the base consonant or syllable base, and all half forms.
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Sinhala incorporates the `REPH_POS_AFTER_MAIN`
 shaping characteristic, this final position is immediately after the
-base consonant or syllable base.
+syllable base.
 
 
 ![Reph positioning](/images/sinhala/sinhala-reph-position.png)

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -300,7 +300,7 @@ characteristics include:
      consonant in `<sinh>` text differs from that used by other
      `BASE_POS_LAST` scripts.
 
-  - `REPH_POS_AFTER_MAIN` = "Reph" is ordered after the base consonant.
+  - `REPH_POS_AFTER_MAIN` = "Reph" is ordered after the base consonant or syllable base.
 
   - `REPH_MODE_EXPLICIT` = "Reph" is formed by an initial "Ra,Halant,ZWJ" sequence.
 
@@ -785,7 +785,7 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be tagged
+Fifth, consonants that occur before the base consonant or syllable base must be tagged
 with `POS_PREBASE_CONSONANT`.
 
 #### 2.6: Reph ####
@@ -802,9 +802,9 @@ Seventh, any non-base consonants that occur after a dependent vowel
 (matra) sign must be tagged with `POS_POSTBASE_CONSONANT`. 
 
 In Sinhala, the only consonants that can appear in this position are
-"Ra" and "Ya". A "Halant,ZWJ,Ya" sequence after the base consonant will take on
+"Ra" and "Ya". A "Halant,ZWJ,Ya" sequence after the base consonant or syllable base will take on
 the "Yansaya" form when the `vatu` feature is applied. A
-"Halant,ZWJ,Ra" sequence after the base consonant will take on 
+"Halant,ZWJ,Ra" sequence after the base consonant or syllable base will take on 
 the "Rakaaraansaya" form when the `vatu` feature is applied.
 
 ![Yansaya ligation](/images/sinhala/sinhala-vatu-va.png)
@@ -1057,7 +1057,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra positioning](/images/sinhala/sinhala-matra-position.png)
 
@@ -1066,7 +1066,7 @@ the base consonant, and all half forms.
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Sinhala incorporates the `REPH_POS_AFTER_MAIN`
 shaping characteristic, this final position is immediately after the
-base consonant.
+base consonant or syllable base.
 
 
 ![Reph positioning](/images/sinhala/sinhala-reph-position.png)
@@ -1121,7 +1121,8 @@ above-base marks or contextually appropriate mark-and-base ligatures.
 ![Above-base substitutions](/images/sinhala/sinhala-abvs.png)
 
 The `blws` feature replaces below-base-consonant glyphs with special
-presentation forms. This usually includes replacing base consonants
+presentation forms. This usually includes replacing base consonants or
+syllable bases
 and attached below-base marks with contextual ligatures.
 
 ![Below-base substitutions](/images/sinhala/sinhala-blws.png)

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -72,6 +72,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.
@@ -152,12 +157,12 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the syllable base to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -307,7 +312,7 @@ track. These include:
     a specific, implicit sequence.
 	
   - Whether the below-base forms feature is applied only to consonants
-    before the base consonant, only to consonants after the base
+    before the syllable base, only to consonants after the base
     consonant, or to both.
 	
   - The ordering positions for dependent vowels
@@ -363,13 +368,36 @@ begin with either a consonant or an independent vowel.
 
 If the syllable begins with a consonant, then the consonant that
 provides the vowel sound is referred to as the "base" consonant. If
-the syllable begins with an independent vowel, that vowel is the
-syllable's only vowel sound and, by definition, there is no "base"
-consonant. 
+the syllable begins with an independent vowel, that independent vowel
+is the syllable's only vowel sound and serves as the "base". 
 
 > Note: A consonant that is not accompanied by a dependent vowel (matra) sign
 > carries the script's inherent vowel sound. This vowel sound is changed
 > by a dependent vowel (matra) sign following the consonant.
+
+From the shaping engine's perspective, the main distinction between a
+syllable with a base consonant and a syllable with an
+independent-vowel base is that a syllable with an independent-vowel
+base is less likely to include additional consonants in special forms
+and less likely to include depedendent vowel signs
+(matras). Therefore, in the common case, vowel-based syllables may
+involve less reordering, substitution feature applications, and other
+processing than consonant-based syllables.
+
+In some languages and orthographies, vowel-based syllables are
+not permitted to include additional consonants or matras, and certain
+GSUB substitution features do not occur. However, there are often
+known exceptions, and real-world text makes no such guarantees. 
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 Generally speaking, the base consonant is the final consonant of the
 syllable and its vowel sound designates the end of the syllable. This
@@ -459,6 +487,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > identification class, and that the other "combining consonant"
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
+
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -598,7 +632,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -620,19 +654,21 @@ which a codepoint might be reordered, across all of the Indic
 scripts. It includes some ordering categories not utilized in
 Tamil. 
 
-The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
-vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+The basic positions (left to right) are "Reph"
+(`POS_RA_TO_BECOME_REPH`), dependent vowels (matras) and consonants
+positioned before the base consonant or syllable base
+(`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base consonant
+or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
-(`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
-and syllable-modifying or Vedic signs (`POS_SMVD`).
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base
+consonant or syllable base (`POS_POSTBASE_CONSONANT`), syllable-final
+consonants (`POS_FINAL_CONSONANT`), and syllable-modifying or Vedic
+signs (`POS_SMVD`).
 
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -646,7 +682,29 @@ For a definition of the "base" consonant, refer to step 2.1, which follows.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
+
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base, and it should be tagged
+as `POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a standalone sequence or other syllable that begins with a placeholder
+or dotted circle, the placeholder or dotted circle will always serve
+as the syllable base, and it should be tagged as
+`POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a syllable that begins with a consonant, the shaping engine must
+determine the base consonant by a script-specific algorithm.
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 The base consonant is defined as the consonant in a consonant-based
 syllable that carries the syllable's vowel sound. That vowel sound
@@ -654,21 +712,15 @@ will either be provided by the script's inherent vowel (in which case
 it is not written with a separate character) or the sound will be designated
 by the addition of a dependent-vowel (matra) sign.
 
-Vowel-based syllables, standalone-sequences, and broken text runs will
-not have base consonants.
 
-> Note: For consistency with consonant-based syllables, shaping
-> engines may choose to treat the independent vowel of a vowel-based
-> syllable as a "pseudo-base" or surrogate base consonant.
->
-> Because vowel-based syllables will not include consonants and
+<!--- > Because vowel-based syllables will not include consonants and
 > because independent vowels do not take on special forms or require
 > reordering, many of the steps that follow will involve no
 > work for a vowel-based syllable. However, vowel-based syllables must
 > still be sorted and their marks handled correctly, and GSUB and GPOS
 > lookups must be applied. These steps of the shaping process follow
 > the same rules that are employed for consonant-based syllables.
-
+--->
 
 While performing the base-consonant search, shaping engines may
 also encounter special-form consonants, including below-base
@@ -719,12 +771,12 @@ them for typographic variation.
 
 > Note: Because Tamil employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search, only the "Halant,_consonant_" 
-> pattern following the base consonant for these below-base forms will
+> pattern following the syllable base for these below-base forms will
 > be encountered. Step 2.5 below ensures that the "_consonant_,Halant"
-> pattern preceding the base consonant for these below-base forms will
+> pattern preceding the syllable base for these below-base forms will
 > also be tagged correctly.
 
 
@@ -793,7 +845,7 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be tagged
+Fifth, consonants that occur before the syllable base must be tagged
 with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences
 that will become "Reph"s: 
 
@@ -820,13 +872,13 @@ them for typographic variation.
 
 > Note: Because Tamil employs the `BLWF_MODE_PRE_AND_POST` shaping
 > characteristic, consonants with below-base special forms may occur
-> before or after the base consonant. 
+> before or after the syllable base. 
 > 
 > During the base-consonant search in 2.1, any instances of the
-> "Halant,_consonant_"  pattern following the base consonant for these
+> "Halant,_consonant_"  pattern following the syllable base for these
 > below-base forms will be encountered. The tagging in this step
-> ensures that the "_consonant_,Halant" pattern preceding the base
-> consonant for these below-base forms will also be tagged correctly.
+> ensures that the "_consonant_,Halant" pattern preceding the syllable
+> base for these below-base forms will also be tagged correctly.
 
 
 #### 2.6: Reph ####
@@ -841,7 +893,7 @@ to maintain compatibility with the other Indic scripts.
 #### 2.7: Final consonants ####
 
 Seventh, all final consonants must be tagged. Consonants that occur
-after the base consonant _and_ after a dependent vowel (matra) sign
+after the syllable base _and_ after a dependent vowel (matra) sign
 must be tagged with  `POS_FINAL_CONSONANT`.
 
 > Note: Final consonants occur only in Sinhala and should not be
@@ -861,32 +913,39 @@ Marks in the `BINDU`, `VISARGA`, `AVAGRAHA`, `CANTILLATION`,
 be tagged with `POS_SMVD`. 
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final sort order.
+
+<!--- EXCEPTION: Uniscribe does NOT move a halant with a preceding -->
+<!--left-matra. HarfBuzz follows suit, for compatibility reasons. --->
+
+<!--- HarfBuzz also tags everything between a post-base consonant or -->
+<!--matra and another post-base consonant as belonging to the latter -->
+<!--post-base consonant. --->
 
 
 ### 3: Applying the basic substitution features from GSUB ###
@@ -1007,9 +1066,9 @@ special forms.
 #### 3.9: half ####
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
-base consonant with "half forms" of the consonant glyphs. There are
-four exceptions to the default behavior, for which the shaping engine
-must test:
+base consonant or syllable base with "half forms" of the consonant
+glyphs. There are four exceptions to the default behavior, for which
+the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been tagged for
     the `rphf` feature earlier, must not be tagged for potential
@@ -1074,10 +1133,10 @@ must be applied after the `half` feature.
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -1091,16 +1150,24 @@ because it was almost certainly lost in the preceding GSUB stage.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -1117,8 +1184,8 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
 
 ![Pre-base matra positioning](/images/tamil/tamil-matra-position.png)
 
@@ -1152,7 +1219,7 @@ compatibility with the other Indic scripts.
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to immediately before
-the base consonant.
+the base consonant or syllable base.
   
 Tamil does not use pre-base-reordering consonants, so this step will
 involve no work when processing `<tml2>` text. It is included here in order

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -1185,7 +1185,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra positioning](/images/tamil/tamil-matra-position.png)
 
@@ -1265,7 +1265,8 @@ above-base marks or contextually appropriate mark-and-base ligatures.
 ![abvs feature application](/images/tamil/tamil-abvs.png)
 
 The `blws` feature replaces below-base-consonant glyphs with special
-presentation forms. This usually includes replacing base consonants that
+presentation forms. This usually includes replacing base consonants or
+syllable bases that
 are adjacent to the below-base marks with contextually appropriate
 ligatures.
 
@@ -1360,7 +1361,7 @@ The old Indic shaping model also did not recognize the
 `BLWF_MODE_PRE_AND_POST` shaping characteristic. Instead, `<taml>`
 was treated as if it followed the `BLWF_MODE_POST_ONLY`
 characteristic. In other words, below-base form substitutions were
-only applied to consonants after the base consonant.
+only applied to consonants after the base consonant or syllable base.
 
 
 ### Advice for handling fonts with `<taml>` features only ###
@@ -1378,7 +1379,7 @@ the `<taml>` script tag and it is known that the font in use supports
 only the `<tml2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant when it is
+below-base consonants occuring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -77,6 +77,11 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
+Syllables may also begin with an **indepedent vowel** instead of a
+consonant. In these syllables, the independent vowel is rendered in
+full-letter form, not as a matra, and the independent vowel serves as the
+syllable base, similar to a base consonant.
+
 Where possible, using the standard terminology is preferred, as the
 use of a language-specific term necessitates choosing one language
 over all of the others that share a common script.
@@ -149,12 +154,12 @@ the shaping process.
 
 There are four basic _mark-placement subclasses_ for dependent vowels
 (matras). Each corresponds to the visual position of the matra with
-respect to the base consonant to which it is attached:
+respect to the syllable base to which it is attached:
 
-  - `LEFT_POSITION` matras are positioned to the left of the base consonant.
-  - `RIGHT_POSITION` matras are positioned to the right of the base consonant.
-  - `TOP_POSITION` matras are positioned above the base consonant.
-  - `BOTTOM_POSITION` matras are positioned below base consonant.
+  - `LEFT_POSITION` matras are positioned to the left of the syllable base.
+  - `RIGHT_POSITION` matras are positioned to the right of the syllable base.
+  - `TOP_POSITION` matras are positioned above the syllable base.
+  - `BOTTOM_POSITION` matras are positioned below syllable base.
   
 These positions may also be referred to elsewhere in shaping documents as:
 
@@ -297,7 +302,7 @@ track. These include:
     a specific, implicit sequence.
 	
   - Whether the below-base forms feature is applied only to consonants
-    before the base consonant, only to consonants after the base
+    before the syllable base, only to consonants after the base
     consonant, or to both.
 	
   - The ordering positions for dependent vowels
@@ -365,13 +370,37 @@ begin with either a consonant or an independent vowel.
 
 If the syllable begins with a consonant, then the consonant that
 provides the vowel sound is referred to as the "base" consonant. If
-the syllable begins with an independent vowel, that vowel is the
-syllable's only vowel sound and, by definition, there is no "base"
-consonant. 
+the syllable begins with an independent vowel, that independent vowel
+is the syllable's only vowel sound and serves as the "base". 
 
 > Note: A consonant that is not accompanied by a dependent vowel (matra) sign
 > carries the script's inherent vowel sound. This vowel sound is changed
 > by a dependent vowel (matra) sign following the consonant.
+
+From the shaping engine's perspective, the main distinction between a
+syllable with a base consonant and a syllable with an
+independent-vowel base is that a syllable with an independent-vowel
+base is less likely to include additional consonants in special forms
+and less likely to include depedendent vowel signs
+(matras). Therefore, in the common case, vowel-based syllables may
+involve less reordering, substitution feature applications, and other
+processing than consonant-based syllables.
+
+In some languages and orthographies, vowel-based syllables are
+not permitted to include additional consonants or matras, and certain
+GSUB substitution features do not occur. However, there are often
+known exceptions, and real-world text makes no such guarantees. 
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
+
 
 Telugu uses the `BASE_POS_LAST` characteristic mentioned
 earlier. However, because all consonants in the script can potentially
@@ -474,6 +503,12 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > identification class, and that the other "combining consonant"
 > cantillation marks in the Devanagari Extended block do not belong to
 > the _consonant_ identification class.
+
+> Note: The _placeholder_ identification class includes codepoints
+> that are often used in place of vowels or consonants when a document
+> needs to display a matra, mark, or special form in isolation or
+> in another context beyond a standard syllable. Examples include
+> hyphens and non-breaking spaces.
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -615,7 +650,7 @@ The final sort order of the ordering categories should be:
 	POS_PREBASE_MATRA
 	POS_PREBASE_CONSONANT
 
-	POS_BASE_CONSONANT
+	POS_SYLLABLE_BASE
 	POS_AFTER_MAIN
 
 	POS_ABOVEBASE_CONSONANT
@@ -637,19 +672,21 @@ which a codepoint might be reordered, across all of the Indic
 scripts. It includes some ordering categories not utilized in
 Telugu. 
 
-The basic positions (left to right) are "Reph" (`POS_RA_TO_BECOME_REPH`), dependent
-vowels (matras) and consonants positioned before the base
-consonant (`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base
-consonant (`POS_BASE_CONSONANT`), above-base consonants
+The basic positions (left to right) are "Reph"
+(`POS_RA_TO_BECOME_REPH`), dependent vowels (matras) and consonants
+positioned before the base consonant or syllable base
+(`POS_PREBASE_MATRA` and `POS_PREBASE_CONSONANT`), the base consonant
+or syllable base (`POS_SYLLABLE_BASE`), above-base consonants
 (`POS_ABOVEBASE_CONSONANT`), below-base consonants
-(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base consonant
-(`POS_POSTBASE_CONSONANT`), syllable-final consonants (`POS_FINAL_CONSONANT`),
-and syllable-modifying or Vedic signs (`POS_SMVD`).
+(`POS_BELOWBASE_CONSONANT`), consonants positioned after the base
+consonant or syllable base (`POS_POSTBASE_CONSONANT`), syllable-final
+consonants (`POS_FINAL_CONSONANT`), and syllable-modifying or Vedic
+signs (`POS_SMVD`).
 
 In addition, several secondary positions are defined to handle various
 reordering rules that deal with relative, rather than absolute,
 positioning. `POS_AFTER_MAIN` means that a character must be
-positioned immediately after the base consonant. `POS_BEFORE_SUBJOINED`
+positioned immediately after the syllable base. `POS_BEFORE_SUBJOINED`
 and `POS_AFTER_SUBJOINED` mean that a character must be positioned
 before or after any below-base consonants, respectively. Similarly,
 `POS_BEFORE_POST` and `POS_AFTER_POST` mean that a character must be
@@ -663,7 +700,29 @@ For a definition of the "base" consonant, refer to step 2.1, which follows.
 #### 2.1: Base consonant ####
 
 The first step is to determine the base consonant of the syllable, if
-there is one, and tag it as `POS_BASE_CONSONANT`.
+there is one, and tag it as `POS_SYLLABLE_BASE`.
+
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base, and it should be tagged
+as `POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a standalone sequence or other syllable that begins with a placeholder
+or dotted circle, the placeholder or dotted circle will always serve
+as the syllable base, and it should be tagged as
+`POS_SYLLABLE_BASE`. The shaping engine can then proceed to step 2.
+
+In a syllable that begins with a consonant, the shaping engine must
+determine the base consonant by a script-specific algorithm.
+
+> Note: Shaping engines may choose to treat independent-vowel bases 
+> like base consonants for the sake of simplicity or code
+> reuse.
+>
+> However, implementations that take this approach should note
+> that removing the distinction between base consonants and
+> independent-vowel bases entirely may have unintended
+> consequences. Making guarantees about the correctness of the results
+> or about language-specific tests is out of scope for this document.
 
 The base consonant is defined as the consonant in a consonant-based
 syllable that carries the syllable's vowel sound. That vowel sound
@@ -671,21 +730,15 @@ will either be provided by the script's inherent vowel (in which case
 it is not written with a separate character) or the sound will be designated
 by the addition of a dependent-vowel (matra) sign.
 
-Vowel-based syllables, standalone-sequences, and broken text runs will
-not have base consonants.
 
-> Note: For consistency with consonant-based syllables, shaping
-> engines may choose to treat the independent vowel of a vowel-based
-> syllable as a "pseudo-base" or surrogate base consonant.
->
-> Because vowel-based syllables will not include consonants and
+<!--- > Because vowel-based syllables will not include consonants and
 > because independent vowels do not take on special forms or require
 > reordering, many of the steps that follow will involve no
 > work for a vowel-based syllable. However, vowel-based syllables must
 > still be sorted and their marks handled correctly, and GSUB and GPOS
 > lookups must be applied. These steps of the shaping process follow
 > the same rules that are employed for consonant-based syllables.
-
+--->
 
 While performing the base-consonant search, shaping engines may
 also encounter special-form consonants, including below-base
@@ -693,7 +746,7 @@ consonants and post-base consonants. Each of these special-form
 consonants must also be tagged (`POS_BELOWBASE_CONSONANT`,
 `POS_POSTBASE_CONSONANT`, respectively). 
 
-Any pre-base-reordering consonant (such as a pre-base-reodering "Ra")
+Any pre-base-reordering consonant (such as a pre-base-reordering "Ra")
 encountered during the base-consonant search must be tagged
 `POS_POSTBASE_CONSONANT`. 
  
@@ -817,7 +870,7 @@ matched later in the shaping process.
 
 #### 2.5: Pre-base consonants ####
 
-Fifth, consonants that occur before the base consonant must be tagged
+Fifth, consonants that occur before the syllable base must be tagged
 with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences
 that will become "Reph"s: 
 
@@ -862,14 +915,14 @@ Sixth, initial "Ra,Halant,ZWJ" sequences that will become "Reph"s must be tagged
 #### 2.7: Final consonants ####
 
 Seventh, all final consonants must be tagged. Consonants that occur
-after the base consonant _and_ after a dependent vowel (matra) sign
+after the syllable base _and_ after a dependent vowel (matra) sign
 must be tagged with  `POS_FINAL_CONSONANT`.
 
 > Note: Final consonants occur only in Sinhala and should not be
 > expected in `<knd2>` text runs. This step is included here to
 > maintain compatibility across Indic scripts.
 
-	
+
 #### 2.8: Mark tagging ####
 
 Eighth, all marks must be tagged. 
@@ -883,32 +936,39 @@ Marks in the `BINDU`, `VISARGA`, `AVAGRAHA`, `CANTILLATION`,
 be tagged with `POS_SMVD`. 
 
 All "Nukta"s must be tagged with the same positioning tag as the
-preceding consonant.
+preceding consonant, independent vowel, placeholder, or dotted circle.
 
 All remaining marks (not in the `POS_SMVD` category and not "Nukta"s)
 must be tagged with the same positioning tag as the closest non-mark
 character the mark has affinity with, so that they move together 
 during the sorting step.
 
-There are two possible cases: those marks before the base consonant
-and those marks after the base consonant.
+There are two possible cases: those marks before the syllable base
+and those marks after the syllable base.
 
   1. Initially, all remaining marks should be tagged with the same
   positioning tag as the closest preceding consonant.
 
-  2. For each consonant after the base consonant (such as post-base
+  2. For each consonant after the syllable base (such as post-base
   consonants, below-base consonants, or final consonants), all
   remaining marks located between that current consonant and any
   previous consonant should be tagged with the same positioning tag as
   the current (later) consonant.
   
-In other words, all consonants preceding the base consonant "own" the
-marks that follow them, while all consonants after the base consonant
+In other words, all consonants preceding the syllable base "own" the
+marks that follow them, while all consonants after the syllable base
 "own" the marks that come before them. When a syllable does not have
-any consonants after the base consonant, the base consonant should
+any consonants after the syllable base, the syllable base should
 "own" all the marks that follow it.
 
 With these steps completed, the syllable can be sorted into the final sort order.
+
+<!--- EXCEPTION: Uniscribe does NOT move a halant with a preceding -->
+<!--left-matra. HarfBuzz follows suit, for compatibility reasons. --->
+
+<!--- HarfBuzz also tags everything between a post-base consonant or -->
+<!--matra and another post-base consonant as belonging to the latter -->
+<!--post-base consonant. --->
 
 
 ### 3: Applying the basic substitution features from GSUB ###
@@ -1006,9 +1066,9 @@ form.
 #### 3.9: half ####
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
-base consonant with "half forms" of the consonant glyphs. There are
-three exceptions to the default behavior, for which the shaping engine
-must test:
+base consonant or syllable base with "half forms" of the consonant
+glyphs. There are three exceptions to the default behavior, for which
+the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been tagged for
     the `rphf` feature earlier, must not be tagged for potential
@@ -1063,10 +1123,10 @@ must be applied after the `half` feature.
 
 The final reordering stage repositions marks, dependent-vowel (matra)
 signs, and "Reph" glyphs to the appropriate location with respect to
-the base consonant. Because multiple substitutions may have occurred
-during the application of the basic-shaping features in the preceding
-stage, these repositioning moves could not be performed during the
-initial reordering stage.
+the base consonant or syllable base. Because multiple substitutions
+may have occurred during the application of the basic-shaping features
+in the preceding stage, these repositioning moves could not be
+performed during the initial reordering stage.
 
 Like the initial reordering stage, the steps involved in this stage
 occur on a per-syllable basis.
@@ -1080,16 +1140,24 @@ because it was almost certainly lost in the preceding GSUB stage.
 #### 4.1: Base consonant ####
 
 The final reordering stage, like the initial reordering stage, begins
-with determining the base consonant of each syllable, following the
+with determining the syllable base of each syllable, following the
 same algorithm used in stage 2, step 1.
 
-The codepoint of the underlying base consonant will not change between
-the search performed in stage 2, step 1, and the search repeated
-here. However, the application of GSUB shaping features in stage 3
-means that several ligation and many-to-one substitutions may have
-taken place. The final glyph produced by that process may, therefore,
-be a conjunct or ligature form — in most cases, such a glyph will not
-have an assigned Unicode codepoint.
+In a syllable that begins with an independent vowel, the independent
+vowel will always serve as the syllable base. In a standalone sequence or
+other syllable that begins with a placeholder or a dotted circle, the
+placeholder or dotted circle will always serve as the syllable base.
+
+In a syllable that begins with a consonant, the shaping engine must
+repeat the base-consonant search algorithm used in stage 2, step 1.
+
+The codepoint of the underlying base consonant or syllable base will
+not change between the search performed in stage 2, step 1, and the
+search repeated here. However, the application of GSUB shaping
+features in stage 3 means that several ligation and many-to-one
+substitutions may have taken place. The final glyph produced by that
+process may, therefore, be a conjunct or ligature form — in most
+cases, such a glyph will not have an assigned Unicode codepoint.
    
 #### 4.2: Pre-base matras ####
 
@@ -1106,8 +1174,9 @@ position is defined as:
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
-consonant, all conjuncts or ligatures that contains the base
-consonant, and all half forms.
+consonant or syllable base, all conjuncts or ligatures that contain
+the base consonant, and all half forms.
+
 
 #### 4.3: Reph ####
 
@@ -1134,7 +1203,7 @@ left of "Halant", to allow for potential matching with `abvs` or
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to before
-the base consonant.
+the base consonant or syllable base.
   
 Telugu includes one such reordering consonant. "Ra" occurring in the
 post-base position is reordered to a pre-base position at this step.

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -424,7 +424,7 @@ mark-like form.
     with a right-side mark called "Reph" (unless the "Ra" is the only
     consonant in the syllable). This rule is synonymous with the
     `REPH_MODE_EXPLICIT` characteristic mentioned earlier.
-  - A post-base "Ra" is reordered to before the base consonant during
+  - A post-base "Ra" is reordered to before the base consonant or syllable base during
     the final-reordering stage of the shaping process. 
 
 "Reph" characters must be reordered after the syllable-identification
@@ -781,7 +781,7 @@ The algorithm for determining the base consonant is
   - The consonant stopped at will be the base consonant.
 
 Telugu includes a pre-base-reordering "Ra".  A "Halant,Ra" sequence
-after the base consonant will be reordered to a pre-base position
+after the base consonant or syllable base will be reordered to a pre-base position
 during the final-reordering stage.
 
 > Note: It is important to note that all consonants in Telugu have a
@@ -793,12 +793,12 @@ during the final-reordering stage.
 
 > Note: Because Telugu employs the `BLWF_MODE_POST_ONLY` shaping
 > characteristic, consonants with below-base special forms will occur
-> only after the base consonant. 
+> only after the base consonant or syllable base. 
 > 
 > During the base-consonant search, therefore, all of these below-base
 > form sequences will be encountered and tagged correctly as
 > "Halant,_consonant_" patterns. Step 2.5 below exists to ensure that
-> the "_consonant_,Halant" pattern preceding the base consonant in
+> the "_consonant_,Halant" pattern preceding the base consonant or syllable base in
 > for below-base forms in other Indic scripts will also be tagged correctly.
 
 
@@ -896,12 +896,12 @@ because it is part of the general processing scheme for shaping Indic scripts.
 
 > Note: Because Telugu employs the `BLWF_MODE_POST_ONLY` shaping
 > characteristic, consonants with below-base special forms will occur
-> only after the base consonant. 
+> only after the base consonant or syllable base. 
 > 
 > During the base-consonant search in 2.1, therefore, all of these below-base
 > form sequences will be encountered and tagged correctly as
 > "Halant,_consonant_" patterns. The tagging is this step ensures that
-> the "_consonant_,Halant" pattern preceding the base consonant in
+> the "_consonant_,Halant" pattern preceding the base consonant or syllable base in
 > for below-base forms in other Indic scripts will also be tagged correctly.
 
 #### 2.6: Reph ####
@@ -1175,7 +1175,7 @@ position is defined as:
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant, and all half forms.
+the base consonant or syllable base, and all half forms.
 
 
 #### 4.3: Reph ####
@@ -1215,7 +1215,7 @@ The algorithm for reordering "Ra" in this circumstance is:
   - Select the final position using [the same method](#42-pre-base-matras) as used for
     reordering a pre-base matra.
   - If the pre-base matra positioning algorithm cannot determine the final
-    position, place the "Ra" immediately before the base consonant.
+    position, place the "Ra" immediately before the base consonant or syllable base.
 
 
 #### 4.5: Initial matras ####

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -798,7 +798,7 @@ during the final-reordering stage.
 > During the base-consonant search, therefore, all of these below-base
 > form sequences will be encountered and tagged correctly as
 > "Halant,_consonant_" patterns. Step 2.5 below exists to ensure that
-> the "_consonant_,Halant" pattern preceding the base consonant or syllable base in
+> the "_consonant_,Halant" pattern preceding the base consonant or syllable base
 > for below-base forms in other Indic scripts will also be tagged correctly.
 
 
@@ -901,7 +901,7 @@ because it is part of the general processing scheme for shaping Indic scripts.
 > During the base-consonant search in 2.1, therefore, all of these below-base
 > form sequences will be encountered and tagged correctly as
 > "Halant,_consonant_" patterns. The tagging is this step ensures that
-> the "_consonant_,Halant" pattern preceding the base consonant or syllable base in
+> the "_consonant_,Halant" pattern preceding the base consonant or syllable base
 > for below-base forms in other Indic scripts will also be tagged correctly.
 
 #### 2.6: Reph ####


### PR DESCRIPTION
This is a rough draft at revising the usage of "base consonant" in the spec to be inclusive — wherever necessary, but no further — of independent-vowel bases and "surrogate" base codepoints like placeholders and dotted circles.

When complete, this will be rolled out to other Indic / Brahmic script docs. For now it was more helpful to implement changes on one specific script, rather than on the more vaguely-worded Indic General.