### PR TITLE
Expand final reph reordering algorithms

### DIFF
--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -1283,8 +1283,15 @@ The algorithm for finding the final "Reph" position is
   - If no such non-ligated post-base consonant is found in the
     previous step, move the "Reph" to the position immediately before
     the first post-base matra, syllable modifier, or Vedic sign that
-    has a positioning tag of `POS_BEFORE_POST` or later. This
-    will be the final "Reph" position.
+    has a positioning tag after the script's "Reph" position in the
+    syllable sort order (as listed in [stage
+    2](#2-initial-reordering)). This will be the final "Reph"
+    position. 
+	> Note: Because Bengali incorporates the
+    > `REPH_POS_AFTER_SUBJOINED` shaping characteristic, this means
+    > any positioning tag of `POS_BEFORE_POST` or later,
+    > although a post-base matra, syllable modifier, or Vedic sign
+    > would not typically be tagged with `POS_BEFORE_POST`.
   - If no other location has been located in the previous steps, move
     the "Reph" to the end of the syllable.
 

--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -1185,10 +1185,13 @@ consonant, and all half forms.
 
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Bengali incorporates the `REPH_POS_AFTER_SUBJOINED`
-shaping characteristic, this final position is immediately after the
-base consonant and any subjoined (below-base consonant or below-base
-dependent vowel) forms.
+shaping characteristic, this final position is defined to be
+immediately after the base consonant and any subjoined (below-base
+consonant or below-base dependent vowel) forms.
 
+The algorithm for finding the final "Reph" position is
+
+<!---
   - If the syllable does not have a base consonant (such as a syllable
     based on an independent vowel), then the final "Reph" position is
     immediately before the first character tagged with the
@@ -1198,6 +1201,34 @@ dependent vowel) forms.
     -- If there are no characters tagged with `POS_BEFORE_POST` or
        later positions, then "Reph" is positioned at the end of the
        syllable.
+--->
+
+  - Starting at the first post-"Reph" consonant, search forward looking
+    for the first explicit "Halant", ending the search when the base
+    consonant is encountered. If such an explicit "Halant" is found,
+    move the "Reph" to the position immediately after this
+    "Halant".
+	  * If a zero-width joiner (ZWJ) or a zero-width non-joiner (ZWNJ)
+        follows this "Halant", move the "Reph" to the position
+        immediately after the ZWJ or ZWNJ. This will be the final
+        "Reph" position. 
+	  * If no ZWJ or ZWNJ follows this "Halant", leave the "Reph" in
+        its position immediately after the "Halant". This will be the
+        final "Reph" position. 
+  - If no such explicit "Halant" is found in the previous step, find
+    the first post-base consonant that has not formed a ligature with
+    the base consonant. If such a non-ligated post-base consonant is
+    found, move the "Reph" to the position immediately before the
+    non-ligated post-base consonant. This will be the final "Reph"
+    position.
+  - If no such non-ligated post-base consonant is found in the
+    previous step, move the "Reph" to the position immediately before
+    the first post-base matra, syllable modifier, or Vedic sign that
+    has a positioning tag of `POS_BEFORE_POST` or later. This
+    will be the final "Reph" position.
+  - If no other location has been located in the previous steps, move
+    the "Reph" to the end of the syllable.
+
 
 Finally, if the final position of "Reph" occurs after a
 "_matra_,Halant" subsequence, then "Reph" must be repositioned to the

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1239,8 +1239,15 @@ The algorithm for finding the final "Reph" position is
   - If no such non-ligated post-base consonant is found in the
     previous step, move the "Reph" to the position immediately before
     the first post-base matra, syllable modifier, or Vedic sign that
-    has a positioning tag of `POS_POSTBASE_CONSONANT` or later. This
-    will be the final "Reph" position.
+    has a positioning tag after the script's "Reph" position in the
+    syllable sort order (as listed in [stage
+    2](#2-initial-reordering)). This will be the final "Reph"
+    position. 
+	> Note: Because Devanagari incorporates the
+    > `REPH_POS_BEFORE_POST` shaping characteristic, this means
+    > any positioning tag of `POS_POSTBASE_CONSONANT` or later,
+    > although a post-base matra, syllable modifier, or Vedic sign
+    > would not typically be tagged with `POS_POSTBASE_CONSONANT`.
   - If no other location has been located in the previous steps, move
     the "Reph" to the end of the syllable.
 

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1186,6 +1186,12 @@ The algorithm for finding the final "Reph" position is
     the "Reph" to the end of the syllable.
 
 
+Finally, if the final position of "Reph" occurs after a
+"_matra_,Halant" subsequence, then "Reph" must be repositioned to the
+left of "Halant", to allow for potential matching with `abvs` or
+`psts` substitutions from GSUB.
+
+
 ![Reph positioning](/images/devanagari/devanagari-reph-position.png)
 
 #### 4.4: Pre-base-reordering consonants ####

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1142,13 +1142,48 @@ consonant, and all half forms.
 
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Devanagari incorporates the `REPH_POS_BEFORE_POST`
-shaping characteristic, this final position is immediately before any
-independent post-base consonant forms (meaning the first post-base
-consonant that has not formed a ligature with the base consonant).
+shaping characteristic, this final position is defined to be
+immediately before any independent post-base consonant forms (meaning
+the first post-base consonant that has not formed a ligature with the
+base consonant).
 
-  - If the syllable does not have any post-base consonants, then the
-    final "Reph" position is immediately before the first post-base
-    matra, syllable modifier, or Vedic sign.
+The algorithm for finding the final "Reph" position is
+
+<!---
+
+  - Find the first explicit "Halant" between the first post-Reph
+    consonant and the last main consonant. Move the "Reph to the
+    position immediately after this "Halant".
+	- If a zero-width joiner (ZWJ) or a zero-width non-joiner (ZWNJ)
+      follows this "Halant", move the "Reph" to the position
+      immediately after the ZWJ or ZWNJ.
+--->
+
+  - Starting at the first post-"Reph" consonant, search forward looking
+    for the first explicit "Halant", ending the search when the base
+    consonant is encountered. If such an explicit "Halant" is found,
+    move the "Reph" to the position immediately after this
+    "Halant".
+	  * If a zero-width joiner (ZWJ) or a zero-width non-joiner (ZWNJ)
+        follows this "Halant", move the "Reph" to the position
+        immediately after the ZWJ or ZWNJ. This will be the final
+        "Reph" position. 
+	  * If no ZWJ or ZWNJ follows this "Halant", leave the "Reph" in
+        its position immediately after the "Halant". This will be the
+        final "Reph" position. 
+  - If no such explicit "Halant" is found in the previous step, find
+    the first post-base consonant that has not formed a ligature with
+    the base consonant. If such a non-ligated post-base consonant is
+    found, move the "Reph" to the position immediately before the
+    non-ligated post-base consonant. This will be the final "Reph"
+    position.
+  - If no such non-ligated post-base consonant is found in the
+    previous step, move the "Reph" to the position immediately before
+    the first post-base matra, syllable modifier, or Vedic sign that
+    has a positioning tag of `POS_POSTBASE_CONSONANT` or later. This
+    will be the final "Reph" position.
+  - If no other location has been located in the previous steps, move
+    the "Reph" to the end of the syllable.
 
 
 ![Reph positioning](/images/devanagari/devanagari-reph-position.png)

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -1194,9 +1194,57 @@ shaping characteristic, this final position is immediately before any
 independent post-base consonant forms (meaning the first post-base
 consonant that has not formed a ligature with the syllable base).
 
-  - If the syllable does not have any post-base consonants, then the
-    final "Reph" position is immediately before the first post-base
-    matra, syllable modifier, or Vedic sign.
+The algorithm for finding the final "Reph" position is
+
+<!---
+
+  - Find the first explicit "Halant" between the first post-Reph
+    consonant and the last main consonant. Move the "Reph to the
+    position immediately after this "Halant".
+	- If a zero-width joiner (ZWJ) or a zero-width non-joiner (ZWNJ)
+      follows this "Halant", move the "Reph" to the position
+      immediately after the ZWJ or ZWNJ.
+--->
+
+  - Starting at the first post-"Reph" consonant, search forward looking
+    for the first explicit "Halant", ending the search when the base
+    consonant is encountered. If such an explicit "Halant" is found,
+    move the "Reph" to the position immediately after this
+    "Halant".
+	  * If a zero-width joiner (ZWJ) or a zero-width non-joiner (ZWNJ)
+        follows this "Halant", move the "Reph" to the position
+        immediately after the ZWJ or ZWNJ. This will be the final
+        "Reph" position. 
+	  * If no ZWJ or ZWNJ follows this "Halant", leave the "Reph" in
+        its position immediately after the "Halant". This will be the
+        final "Reph" position. 
+  - If no such explicit "Halant" is found in the previous step, find
+    the first post-base consonant that has not formed a ligature with
+    the base consonant. If such a non-ligated post-base consonant is
+    found, move the "Reph" to the position immediately before the
+    non-ligated post-base consonant. This will be the final "Reph"
+    position.
+  - If no such non-ligated post-base consonant is found in the
+    previous step, move the "Reph" to the position immediately before
+    the first post-base matra, syllable modifier, or Vedic sign that
+    has a positioning tag after the script's "Reph" position in the
+    syllable sort order (as listed in [stage
+    2](#2-initial-reordering)). This will be the final "Reph"
+    position. 
+	> Note: Because Gujarati incorporates the
+    > `REPH_POS_BEFORE_POST` shaping characteristic, this means
+    > any positioning tag of `POS_POSTBASE_CONSONANT` or later,
+    > although a post-base matra, syllable modifier, or Vedic sign
+    > would not typically be tagged with `POS_POSTBASE_CONSONANT`.
+  - If no other location has been located in the previous steps, move
+    the "Reph" to the end of the syllable.
+
+
+Finally, if the final position of "Reph" occurs after a
+"_matra_,Halant" subsequence, then "Reph" must be repositioned to the
+left of "Halant", to allow for potential matching with `abvs` or
+`psts` substitutions from GSUB.
+
 
 
 

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -1197,10 +1197,46 @@ consonant, and all half forms.
 
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Gurmukhi incorporates the `REPH_POS_BEFORE_SUBJOINED`
-shaping characteristic, this final position is immediately after the
-base consonant and before any subjoined (below-base consonant or below-base
-dependent vowel) forms.
+shaping characteristic, this final position is defined to be
+immediately after the base consonant and before any subjoined
+(below-base consonant or below-base dependent vowel) forms.
 
+The algorithm for finding the final "Reph" position is
+
+  - Starting at the first post-"Reph" consonant, search forward looking
+    for the first explicit "Halant", ending the search when the base
+    consonant is encountered. If such an explicit "Halant" is found,
+    move the "Reph" to the position immediately after this
+    "Halant".
+	  * If a zero-width joiner (ZWJ) or a zero-width non-joiner (ZWNJ)
+        follows this "Halant", move the "Reph" to the position
+        immediately after the ZWJ or ZWNJ. This will be the final
+        "Reph" position. 
+	  * If no ZWJ or ZWNJ follows this "Halant", leave the "Reph" in
+        its position immediately after the "Halant". This will be the
+        final "Reph" position. 
+  - If no such explicit "Halant" is found in the previous step, find
+    the first post-base consonant that has not formed a ligature with
+    the base consonant. If such a non-ligated post-base consonant is
+    found, move the "Reph" to the position immediately before the
+    non-ligated post-base consonant. This will be the final "Reph"
+    position.
+  - If no such non-ligated post-base consonant is found in the
+    previous step, move the "Reph" to the position immediately before
+    the first post-base matra, syllable modifier, or Vedic sign that
+    has a positioning tag of `POS_BELOWBASE_CONSONANT` or later. This
+    will be the final "Reph" position.
+  - If no other location has been located in the previous steps, move
+    the "Reph" to the end of the syllable.
+
+
+Finally, if the final position of "Reph" occurs after a
+"_matra_,Halant" subsequence, then "Reph" must be repositioned to the
+left of "Halant", to allow for potential matching with `abvs` or
+`psts` substitutions from GSUB.
+
+
+<!---
   - If the syllable does not have a base consonant (such as a syllable
     based on an independent vowel), then the final "Reph" position is
     immediately before the first character tagged with the
@@ -1215,7 +1251,7 @@ Finally, if the final position of "Reph" occurs after a
 "_matra_,Halant" subsequence, then "Reph" must be repositioned to the
 left of "Halant", to allow for potential matching with `abvs` or
 `psts` substitutions from GSUB.
-
+--->
 #### 4.4: Pre-base-reordering consonants ####
 
 Any pre-base-reordering consonants must be moved to immediately before

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -1282,8 +1282,15 @@ The algorithm for finding the final "Reph" position is
   - If no such non-ligated post-base consonant is found in the
     previous step, move the "Reph" to the position immediately before
     the first post-base matra, syllable modifier, or Vedic sign that
-    has a positioning tag of `POS_BELOWBASE_CONSONANT` or later. This
-    will be the final "Reph" position.
+    has a positioning tag after the script's "Reph" position in the
+    syllable sort order (as listed in [stage
+    2](#2-initial-reordering)). This will be the final "Reph"
+    position. 
+	> Note: Because Gurmukhi incorporates the
+    > `REPH_POS_BEFORE_SUBJOINED` shaping characteristic, this means
+    > any positioning tag of `POS_BELOWBASE_CONSONANT` or later,
+    > although a post-base matra, syllable modifier, or Vedic sign
+    > would not typically be tagged with `POS_BELOWBASE_CONSONANT`.
   - If no other location has been located in the previous steps, move
     the "Reph" to the end of the syllable.
 

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -1323,7 +1323,7 @@ Reph-position shaping characteristic, and is conditional upon the
 presence or absence of certain characters (such as post-base
 consonants or "matra,Halant" sequences) in the syllable. 
 
-The algorithm for determining the final Reph position has seven steps.
+The full algorithm for determining the final Reph position has seven steps.
 
 (a) If the script uses Reph-position rule `REPH_POS_AFTER_POST`, jump
 immediately to step (e). Otherwise, proceed to step (b).
@@ -1353,8 +1353,10 @@ Reph-position rule, proceed to step (e).
 
 (e) Move the "Reph" to a position immediately before the first
 post-base matra, syllable modifier sign or Vedic sign that has a
-reordering class after the intended Reph position, then proceed to
-step (mH). If no such matra or sign is found, proceed to step (f).
+reordering class after the intended Reph position in the syllable sort
+order (as listed in [stage 2](#2-initial-reordering)). This will be
+the final "Reph" position. , then proceed to step (mH). If no such
+matra or sign is found, proceed to step (f).
 
 (f) Move the "Reph" to the end of the syllable. 
 

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -1319,7 +1319,66 @@ the base consonant or syllable base, and all half forms.
 
 "Reph" must be moved from the beginning of the syllable to its final
 position. The correct final position depends on the script's
-`REPH_MODE_`. See the individual script pages for more information.
+Reph-position shaping characteristic, and is conditional upon the
+presence or absence of certain characters (such as post-base
+consonants or "matra,Halant" sequences) in the syllable. 
+
+The algorithm for determining the final Reph position has seven steps.
+
+(a) If the script uses Reph-position rule `REPH_POS_AFTER_POST`, jump
+immediately to step (e). Otherwise, proceed to step (b).
+
+(b) Find the first explicit "Halant" between the syllable base
+consonant and the first post-Reph consonant. If there is a ZWJ or ZWNJ
+following this "Halant", move the "Reph" to a position immediately
+after the ZWJ or ZWNJ, then proceed to step (mH). Otherwise, move the
+"Reph" to a position immediately after the "Halant", then proceed to
+step (mH). If no such explicit "Halant" is found, proceed to step
+(c).
+
+(c) If the script uses Reph-position rule `REPH_POS_AFTER_MAIN`, find
+the first consonant not ligated with the syllable base, and that is
+not a potential pre-base reordering "Ra". If such a consonant is
+found, move the "Reph" to a position immediately after the
+consonant, then proceed to step (mH). If no such consonant is found,
+proceed to step (d). If the script uses a different Reph-position
+rule, proceed to step (d).
+
+(d) If the script uses Reph-position rule `REPH_POS_BEFORE_POST`, find
+the first post-base consonant not ligated with the syllable base. If
+such a consonant is found, move the "Reph" to a position immediately
+before the consonant, then proceed to step (mH). If no such consonant
+is found, proceed to step (e). If the script uses a different
+Reph-position rule, proceed to step (e).
+
+(e) Move the "Reph" to a position immediately before the first
+post-base matra, syllable modifier sign or Vedic sign that has a
+reordering class after the intended Reph position, then proceed to
+step (mH). If no such matra or sign is found, proceed to step (f).
+
+(f) Move the "Reph" to the end of the syllable. 
+
+(mH) Finally, if the "Reph" position arrived at in the preceding steps
+is immediately after a "matra,Halant" sequence, move the "Reph" so
+that it is before the "Halant". 
+
+
+Taking the Reph-position–rule conditionals in the above algorithm into
+account, the position-finding steps that may be executed in each
+script are summarized in the following table:
+
+| Script     | Reph-position rule        | a | b | c | d | e | f | mH |
+|:-----------|:--------------------------|:--|:--|:--|:--|:--|:--|:---|
+| Devanagari |`REPH_POS_BEFORE_POST`     |   | • |   | • | • | • | •  |
+| Bengali    |`REPH_POS_AFTER_SUBJOINED` |   | • |   |   |   | • | •  |
+| Gujarati   |`REPH_POS_BEFORE_POST`     |   | • |   | • | • | • | •  |
+| Gurmukhi   |`REPH_POS_BEFORE_SUBJOINED`|   | • |   |   |   | • | •  |
+| Kannada    |`REPH_POS_AFTER_POST`      |   |   |   |   | • | • | •  |
+| Malayalam  |`REPH_POS_AFTER_MAIN`      |   | • | • |   | • | • | •  |
+| Oriya      |`REPH_POS_AFTER_MAIN`      |   | • | • |   | • | • | •  |
+| Tamil      |`REPH_POS_AFTER_POST`      |   |   |   |   | • | • | •  |
+| Telugu     |`REPH_POS_AFTER_POST`      |   |   |   |   | • | • | •  |
+| Sinhala    |`REPH_POS_AFTER_MAIN`      |   | • | • |   | • | • | •  |
 
 #### 4.4: Pre-base reordering consonants ####
 

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -1160,18 +1160,19 @@ order to maintain compatibility with the other Indic scripts.
 
 "Reph" must be moved from the beginning of the syllable to its final
 position. Because Kannada incorporates the `REPH_POS_AFTER_POST`
-shaping characteristic, this final position is immediately after
-any post-base consonant forms.
+shaping characteristic, this final position is defined to be
+immediately after any post-base consonant forms.
 
-  - If the syllable does not have a base consonant (such as a syllable
-    based on an independent vowel), then the final "Reph" position is
-    immediately before the first character tagged with the
-    `POS_BEFORE_POST` position or any later position in the sort
-    order.
 
-    -- If there are no characters tagged with `POS_BEFORE_POST` or
-       later positions, then "Reph" is positioned at the end of the
-       syllable.
+The algorithm for finding the final "Reph" position is
+
+  - Move the "Reph" to the position immediately before
+    the first post-base matra, syllable modifier, or Vedic sign that
+    has a positioning tag of `POS_FINAL_CONSONANT` or later. This
+    will be the final "Reph" position.
+  - If no other location has been located in the previous step, move
+    the "Reph" to the end of the syllable.
+
 
 Finally, if the final position of "Reph" occurs after a
 "_matra_,Halant" subsequence, then "Reph" must be repositioned to the

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -1210,8 +1210,15 @@ The algorithm for finding the final "Reph" position is
 
   - Move the "Reph" to the position immediately before
     the first post-base matra, syllable modifier, or Vedic sign that
-    has a positioning tag of `POS_FINAL_CONSONANT` or later. This
-    will be the final "Reph" position.
+    has a positioning tag after the script's "Reph" position in the
+    syllable sort order (as listed in [stage
+    2](#2-initial-reordering)). This will be the final "Reph"
+    position. 
+	> Note: Because Kannada incorporates the
+    > `REPH_POS_AFTER_POST` shaping characteristic, this means
+    > any positioning tag of `POS_FINAL_CONSONANT` or later,
+    > although a post-base matra, syllable modifier, or Vedic sign
+    > would not typically be tagged with `POS_FINAL_CONSONANT`.
   - If no other location has been located in the previous step, move
     the "Reph" to the end of the syllable.
 

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -1196,18 +1196,18 @@ consonant, and all half forms.
 
 "Reph" or "Repha" must be moved from the beginning of the syllable to its final
 position. Because Malayalam incorporates the `REPH_POS_AFTER_MAIN`
-shaping characteristic, this final position is immediately after the
-base consonant.
+shaping characteristic, this final position is defined as immediately
+after the base consonant.
 
-  - If the syllable does not have a base consonant (such as a syllable
-    based on an independent vowel), then the final "Reph" position is
-    immediately before the first character tagged with the
-    `POS_BEFORE_POST` position or any later position in the sort
-    order.
+The algorithm for finding the final "Reph" position is
 
-    -- If there are no characters tagged with `POS_BEFORE_POST` or
-       later positions, then "Reph" is positioned at the end of the
-       syllable.
+  - If no such non-ligated post-base consonant is found in the
+    previous step, move the "Reph" to the position immediately before
+    the first post-base matra, syllable modifier, or Vedic sign that
+    has a positioning tag of `POS_ABOVEBASE_CONSONANT` or later. This
+    will be the final "Reph" position.
+  - If no other location has been located in the previous step, move
+    the "Reph" to the end of the syllable.
 
 Finally, if the final position of "Reph" or "Repha" occurs after a
 "_matra_,Halant" subsequence, then "Reph"/"Repha" must be repositioned to the

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -1265,11 +1265,17 @@ after the syllable base.
 
 The algorithm for finding the final "Reph" position is
 
-  - If no such non-ligated post-base consonant is found in the
-    previous step, move the "Reph" to the position immediately before
+  - Move the "Reph" to the position immediately before
     the first post-base matra, syllable modifier, or Vedic sign that
-    has a positioning tag of `POS_ABOVEBASE_CONSONANT` or later. This
-    will be the final "Reph" position.
+    has a positioning tag after the script's "Reph" position in the
+    syllable sort order (as listed in [stage
+    2](#2-initial-reordering)). This will be the final "Reph"
+    position. 
+	> Note: Because Malayalam incorporates the
+    > `REPH_POS_AFTER_MAIN` shaping characteristic, this means
+    > any positioning tag of `POS_ABOVEBASE_CONSONANT` or later,
+    > although a post-base matra, syllable modifier, or Vedic sign
+    > would not typically be tagged with `POS_ABOVEBASE_CONSONANT`.
   - If no other location has been located in the previous step, move
     the "Reph" to the end of the syllable.
 

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -1256,18 +1256,24 @@ position. Because Oriya incorporates the `REPH_POS_AFTER_MAIN`
 shaping characteristic, this final position is immediately after the
 syllable base.
 
-  - If the syllable does not have a base consonant (such as a syllable
-    based on an independent vowel), then the final "Reph" position is
-    immediately before the first character tagged with the
-    `POS_BEFORE_POST` position or any later position in the sort
-    order.
+The algorithm for finding the final "Reph" position is
 
-    -- If there are no characters tagged with `POS_BEFORE_POST` or
-       later positions, then "Reph" is positioned at the end of the
-       syllable.
+  - Move the "Reph" to the position immediately before
+    the first post-base matra, syllable modifier, or Vedic sign that
+    has a positioning tag after the script's "Reph" position in the
+    syllable sort order (as listed in [stage
+    2](#2-initial-reordering)). This will be the final "Reph"
+    position. 
+	> Note: Because Oriya incorporates the
+    > `REPH_POS_AFTER_MAIN` shaping characteristic, this means
+    > any positioning tag of `POS_ABOVEBASE_CONSONANT` or later,
+    > although a post-base matra, syllable modifier, or Vedic sign
+    > would not typically be tagged with `POS_ABOVEBASE_CONSONANT`.
+  - If no other location has been located in the previous step, move
+    the "Reph" to the end of the syllable.
 
-Finally, if the final position of "Reph" occurs after a
-"_matra_,Halant" subsequence, then "Reph" must be repositioned to the
+Finally, if the final position of "Reph" or "Repha" occurs after a
+"_matra_,Halant" subsequence, then "Reph"/"Repha" must be repositioned to the
 left of "Halant", to allow for potential matching with `abvs` or
 `psts` substitutions from GSUB.
 

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -1067,6 +1067,27 @@ position. Because Sinhala incorporates the `REPH_POS_AFTER_MAIN`
 shaping characteristic, this final position is immediately after the
 syllable base.
 
+The algorithm for finding the final "Reph" position is
+
+  - Move the "Reph" to the position immediately before
+    the first post-base matra, syllable modifier, or Vedic sign that
+    has a positioning tag after the script's "Reph" position in the
+    syllable sort order (as listed in [stage
+    2](#2-initial-reordering)). This will be the final "Reph"
+    position. 
+	> Note: Because Sinhala incorporates the
+    > `REPH_POS_AFTER_MAIN` shaping characteristic, this means
+    > any positioning tag of `POS_ABOVEBASE_CONSONANT` or later,
+    > although a post-base matra, syllable modifier, or Vedic sign
+    > would not typically be tagged with `POS_ABOVEBASE_CONSONANT`.
+  - If no other location has been located in the previous step, move
+    the "Reph" to the end of the syllable.
+
+Finally, if the final position of "Reph" or "Repha" occurs after a
+"_matra_,Halant" subsequence, then "Reph"/"Repha" must be repositioned to the
+left of "Halant", to allow for potential matching with `abvs` or
+`psts` substitutions from GSUB.
+
 
 ![Reph positioning](/images/sinhala/sinhala-reph-position.png)
 

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -1195,15 +1195,23 @@ position. Because Tamil incorporates the `REPH_POS_AFTER_POST`
 shaping characteristic, this final position is immediately after
 any post-base consonant forms.
 
-  - If the syllable does not have a base consonant (such as a syllable
-    based on an independent vowel), then the final "Reph" position is
-    immediately before the first character tagged with the
-    `POS_BEFORE_POST` position or any later position in the sort
-    order.
 
-    -- If there are no characters tagged with `POS_BEFORE_POST` or
-       later positions, then "Reph" is positioned at the end of the
-       syllable.
+The algorithm for finding the final "Reph" position is
+
+  - Move the "Reph" to the position immediately before
+    the first post-base matra, syllable modifier, or Vedic sign that
+    has a positioning tag after the script's "Reph" position in the
+    syllable sort order (as listed in [stage
+    2](#2-initial-reordering)). This will be the final "Reph"
+    position. 
+	> Note: Because Tamil incorporates the
+    > `REPH_POS_AFTER_POST` shaping characteristic, this means
+    > any positioning tag of `POS_FINAL_CONSONANT` or later,
+    > although a post-base matra, syllable modifier, or Vedic sign
+    > would not typically be tagged with `POS_FINAL_CONSONANT`.
+  - If no other location has been located in the previous step, move
+    the "Reph" to the end of the syllable.
+
 
 Finally, if the final position of "Reph" occurs after a
 "_matra_,Halant" subsequence, then "Reph" must be repositioned to the

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -1184,15 +1184,23 @@ position. Because Telugu incorporates the `REPH_POS_AFTER_POST`
 shaping characteristic, this final position is immediately after 
 any post-base consonant forms.
 
-  - If the syllable does not have a base consonant (such as a syllable
-    based on an independent vowel), then the final "Reph" position is
-    immediately before the first character tagged with the
-    `POS_BEFORE_POST` position or any later position in the sort
-    order.
 
-    -- If there are no characters tagged with `POS_BEFORE_POST` or
-       later positions, then "Reph" is positioned at the end of the
-       syllable.
+The algorithm for finding the final "Reph" position is
+
+  - Move the "Reph" to the position immediately before
+    the first post-base matra, syllable modifier, or Vedic sign that
+    has a positioning tag after the script's "Reph" position in the
+    syllable sort order (as listed in [stage
+    2](#2-initial-reordering)). This will be the final "Reph"
+    position. 
+	> Note: Because Telugu incorporates the
+    > `REPH_POS_AFTER_POST` shaping characteristic, this means
+    > any positioning tag of `POS_FINAL_CONSONANT` or later,
+    > although a post-base matra, syllable modifier, or Vedic sign
+    > would not typically be tagged with `POS_FINAL_CONSONANT`.
+  - If no other location has been located in the previous step, move
+    the "Reph" to the end of the syllable.
+
 
 Finally, if the final position of "Reph" occurs after a
 "_matra_,Halant" subsequence, then "Reph" must be repositioned to the


### PR DESCRIPTION
In-progress updates to final-"Reph" reordering. Currently Devanagari (REPH_POS_BEFORE_POST), Bengali (REPH_POS_AFTER_SUBJOINED), and Kannada (REPH_POS_BEFORE_POST).

[edit] Adding Gurmukhi (REPH_POS_BEFORE_SUBJOINED) and Malayalam (REPH_POS_AFTER_MAIN).