### PR TITLE
Improve base-algorithm ZWJ and pre-base ZWJ

### DIFF
--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -791,11 +791,12 @@ encountered during the base-consonant search must be tagged
 
 The algorithm for determining the base consonant is
 
-  - If the syllable starts with "Ra" and the syllable contains
+  - If the syllable starts with "Ra,Halant" and the syllable contains
     more than one consonant, exclude the starting "Ra" from the list of
     consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is the first consonant, stop.
+      * If the consonant is preceded by the sequence "Halant,ZWJ", stop.
       * If the consonant has a below-base form, tag it as
         `POS_BELOWBASE_CONSONANT`, then move to the previous consonant. 
       * If the consonant has a post-base form, tag it as

--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -251,21 +251,26 @@ in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
 The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+from a "_Consonant_,Halant,_Consonant_" sequence. 
+
+  - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
+    formation of a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner must be used instead.
+
+  - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
+    the first consonant in its standard form, followed by an explicit
+    "Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
-where an initial "Ra,Halant" sequence without the zero-width joiner
-otherwise would.
+"Reph". 
+
+  - An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
+    even where an initial "Ra,Halant" sequence without the zero-width
+    joiner would otherwise produce a "Reph".
 
 The no-break space is primarily used to display those codepoints that
 are defined as non-spacing (marks, dependent vowels (matras),

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -755,11 +755,12 @@ encountered during the base-consonant search must be tagged
 
 The algorithm for determining the base consonant is
 
-  - If the syllable starts with "Ra" and the syllable contains
+  - If the syllable starts with "Ra,Halant" and the syllable contains
     more than one consonant, exclude the starting "Ra" from the list of
     consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is the first consonant, stop.
+      * If the consonant is preceded by the sequence "Halant,ZWJ", stop.
       * If the consonant has a below-base form, tag it as
         `POS_BELOWBASE_CONSONANT`, then move to the previous consonant. 
       * If the consonant has a post-base form, tag it as

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -242,21 +242,26 @@ in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
 The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+from a "_Consonant_,Halant,_Consonant_" sequence. 
+
+  - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
+    formation of a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner must be used instead.
+
+  - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
+    the first consonant in its standard form, followed by an explicit
+    "Halant". 
 
 A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
-where an initial "Ra,Halant" sequence without the zero-width joiner
-otherwise would.
+"Reph".
+
+  - An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
+    even where an initial "Ra,Halant" sequence without the zero-width
+    joiner would otherwise produce a "Reph".
 
 The no-break space is primarily used to display those codepoints that
 are defined as non-spacing (marks, dependent vowels (matras),

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -744,11 +744,12 @@ encountered during the base-consonant search must be tagged
 
 The algorithm for determining the base consonant is
 
-  - If the syllable starts with "Ra" and the syllable contains
+  - If the syllable starts with "Ra,Halant" and the syllable contains
     more than one consonant, exclude the starting "Ra" from the list of
     consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is the first consonant, stop.
+      * If the consonant is preceded by the sequence "Halant,ZWJ", stop.
       * If the consonant has a below-base form, tag it as
         `POS_BELOWBASE_CONSONANT`, then move to the previous consonant. 
       * If the consonant has a post-base form, tag it as

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -237,21 +237,26 @@ in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
 The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+from a "_Consonant_,Halant,_Consonant_" sequence.
+
+  - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
+    formation of a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner must be used instead.
+
+  - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
+    the first consonant in its standard form, followed by an explicit
+    "Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
-where an initial "Ra,Halant" sequence without the zero-width joiner
-otherwise would.
+"Reph".
+
+  - An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
+    even where an initial "Ra,Halant" sequence without the zero-width
+    joiner would otherwise produce a "Reph".
 
 The no-break space is primarily used to display those codepoints that
 are defined as non-spacing (marks, dependent vowels (matras),

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -798,11 +798,12 @@ encountered during the base-consonant search must be tagged
 
 The algorithm for determining the base consonant is
 
-  - If the syllable starts with "Ra" and the syllable contains
+  - If the syllable starts with "Ra,Halant" and the syllable contains
     more than one consonant, exclude the starting "Ra" from the list of
     consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is the first consonant, stop.
+      * If the consonant is preceded by the sequence "Halant,ZWJ", stop.
       * If the consonant has a below-base form, tag it as
         `POS_BELOWBASE_CONSONANT`, then move to the previous consonant. 
       * If the consonant has a post-base form, tag it as

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -275,21 +275,26 @@ in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
 The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+from a "_Consonant_,Halant,_Consonant_" sequence.
+
+  - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
+    formation of a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner must be used instead.
+
+  - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
+    the first consonant in its standard form, followed by an explicit
+    "Halant". 
 
 A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
-where an initial "Ra,Halant" sequence without the zero-width joiner
-otherwise would.
+"Reph".
+
+  - An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
+    even where an initial "Ra,Halant" sequence without the zero-width
+    joiner would otherwise produce a "Reph".
 
 > Note: "Reph" substitutions are rare in Gurmukhi text. `<gur2>` fonts may
 > not implement the "Reph" substitution in GSUB at all. Nevertheless,

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -256,21 +256,26 @@ in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
 The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+from a "_Consonant_,Halant,_Consonant_" sequence. 
+
+  - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
+    formation of a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner must be used instead. 
+
+  - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
+    the first consonant in its standard form, followed by an explicit
+    "Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
-where an initial "Ra,Halant" sequence without the zero-width joiner
-otherwise would.
+"Reph". 
+
+  - An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
+    even where an initial "Ra,Halant" sequence without the zero-width
+    joiner would otherwise produce a "Reph".
 
 The no-break space is primarily used to display those codepoints that
 are defined as non-spacing (marks, dependent vowels (matras),
@@ -758,11 +763,12 @@ encountered during the base-consonant search must be tagged
 
 The algorithm for determining the base consonant is
 
-  - If the syllable starts with "Ra" and the syllable contains
+  - If the syllable starts with "Ra,Halant" and the syllable contains
     more than one consonant, exclude the starting "Ra" from the list of
     consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is the first consonant, stop.
+      * If the consonant is preceded by the sequence "Halant,ZWJ", stop.
       * If the consonant has a below-base form, tag it as
         `POS_BELOWBASE_CONSONANT`, then move to the previous consonant. 
       * If the consonant has a post-base form, tag it as

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -792,11 +792,12 @@ encountered during the base-consonant search must be tagged
 
 The algorithm for determining the base consonant is
 
-  - If the syllable starts with "Ra" and the syllable contains
+  - If the syllable starts with "Ra,Halant" and the syllable contains
     more than one consonant, exclude the starting "Ra" from the list of
     consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is the first consonant, stop.
+      * If the consonant is preceded by the sequence "Halant,ZWJ", stop.
       * If the consonant has a below-base form, tag it as
         `POS_BELOWBASE_CONSONANT`, then move to the previous consonant. 
       * If the consonant has a post-base form, tag it as

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -264,21 +264,26 @@ in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
 The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+from a "_Consonant_,Halant,_Consonant_" sequence.
+
+  - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
+    formation of a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner must be used instead.
+
+  - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
+    the first consonant in its standard form, followed by an explicit
+    "Halant". 
 
 A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
-where an initial "Ra,Halant" sequence without the zero-width joiner
-otherwise would.
+"Reph".
+
+  - An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
+    even where an initial "Ra,Halant" sequence without the zero-width
+    joiner would otherwise produce a "Reph".
 
 The no-break space is primarily used to display those codepoints that
 are defined as non-spacing (marks, dependent vowels (matras),

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -1261,7 +1261,8 @@ cases, such a glyph will not have an assigned Unicode codepoint.
 Pre-base dependent vowels (matras) that were reordered during the
 initial reordering stage must be moved to their final position. This
 position is defined as:
-   
+
+   - after all "Chillu" glyphs
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
@@ -1270,9 +1271,10 @@ position is defined as:
      after the joiner or non-joiner.
 
 This means that the matra will move to the right of all explicit
-"consonant,Halant" subsequences, but will stop to the left of the base
-consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant or syllable base, and all half forms.
+"_Consonant_,Halant" subsequences and all glyphs that resulted from a
+substitution on a "_Consonant_,Halant,ZWJ" subsequence, but will stop
+to the left of the base consonant or syllable base, and all conjuncts
+or ligatures that contain the base consonant or syllable base.
 
 ![Matra positioning](/images/malayalam/malayalam-matra-position.png)
 

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -235,21 +235,26 @@ in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
 The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+from a "_Consonant_,Halant,_Consonant_" sequence.
+
+  - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
+    formation of a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner must be used instead.
+
+  - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
+    the first consonant in its standard form, followed by an explicit
+    "Halant". 
 
 A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
-where an initial "Ra,Halant" sequence without the zero-width joiner
-otherwise would.
+"Reph".
+
+  - An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
+    even where an initial "Ra,Halant" sequence without the zero-width
+    joiner would otherwise produce a "Reph".
 
 The no-break space is primarily used to display those codepoints that
 are defined as non-spacing (marks, dependent vowels (matras),

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -797,11 +797,12 @@ encountered during the base-consonant search must be tagged
 
 The algorithm for determining the base consonant is
 
-  - If the syllable starts with "Ra" and the syllable contains
+  - If the syllable starts with "Ra,Halant" and the syllable contains
     more than one consonant, exclude the starting "Ra" from the list of
     consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is the first consonant, stop.
+      * If the consonant is preceded by the sequence "Halant,ZWJ", stop.
       * If the consonant has a below-base form, tag it as
         `POS_BELOWBASE_CONSONANT`, then move to the previous consonant. 
       * If the consonant has a post-base form, tag it as

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -747,11 +747,12 @@ encountered during the base-consonant search must be tagged
 
 The algorithm for determining the base consonant is
 
-  - If the syllable starts with "Ra" and the syllable contains
+  - If the syllable starts with "Ra,Halant" and the syllable contains
     more than one consonant, exclude the starting "Ra" from the list of
     consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is the first consonant, stop.
+      * If the consonant is preceded by the sequence "Halant,ZWJ", stop.
       * If the consonant has a below-base form, tag it as
         `POS_BELOWBASE_CONSONANT`, then move to the previous consonant. 
       * If the consonant has a post-base form, tag it as

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -252,21 +252,26 @@ in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
 The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+from a "_Consonant_,Halant,_Consonant_" sequence.
+
+  - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
+    formation of a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner must be used instead.
+
+  - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
+    the first consonant in its standard form, followed by an explicit
+    "Halant". 
 
 A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
-where an initial "Ra,Halant" sequence without the zero-width joiner
-otherwise would.
+"Reph".
+
+  - An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
+    even where an initial "Ra,Halant" sequence without the zero-width
+    joiner would otherwise produce a "Reph".
 
 The no-break space is primarily used to display those codepoints that
 are defined as non-spacing (marks, dependent vowels (matras),

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -1107,7 +1107,8 @@ the shaping engine must test:
 
 > Note: Tamil does not usually incorporate half forms, but it is
 > possible for a font to implement them in order to provide for
-> desired typographic variation.
+> desired typographic variation. For example, a font may substitute a
+> ligature of the "_Consonant_" and "Halant" glyphs.
 
 ![half-form feature application](/images/tamil/tamil-half.png)
 
@@ -1193,7 +1194,9 @@ cases, such a glyph will not have an assigned Unicode codepoint.
 Pre-base dependent vowels (matras) that were reordered during the
 initial reordering stage must be moved to their final position. This
 position is defined as:
-   
+
+   - after any ligature glyphs that resulted from the substitution of
+     a "_Consonant_,Halant,ZWJ" subsequence
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
@@ -1202,9 +1205,10 @@ position is defined as:
      after the joiner or non-joiner.
 
 This means that the matra will move to the right of all explicit
-"consonant,Halant" subsequences, but will stop to the left of the base
-consonant or syllable base, all conjuncts or ligatures that contain
-the base consonant or syllable base, and all half forms.
+"consonant,Halant" subsequences and all glyphs that resulted from a
+substitution on a "_Consonant_,Halant,ZWJ" subsequence, but will stop
+to the left of the base consonant or syllable base, and all conjuncts
+or ligatures that contain the base consonant or syllable base.
 
 ![Pre-base matra positioning](/images/tamil/tamil-matra-position.png)
 

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -243,21 +243,26 @@ in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
 The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+from a "_Consonant_,Halant,_Consonant_" sequence.
+
+  - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
+    formation of a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner must be used instead.
+
+  - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
+    the first consonant in its standard form, followed by an explicit
+    "Halant". 
 
 A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
-where an initial "Ra,Halant" sequence without the zero-width joiner
-otherwise would.
+"Reph".
+
+  - An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
+    even where an initial "Ra,Halant" sequence without the zero-width
+    joiner would otherwise produce a "Reph".
 
 The no-break space is primarily used to display those codepoints that
 are defined as non-spacing (marks, dependent vowels (matras),

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -765,11 +765,12 @@ encountered during the base-consonant search must be tagged
 
 The algorithm for determining the base consonant is
 
-  - If the syllable starts with "Ra" and the syllable contains
+  - If the syllable starts with "Ra,Halant" and the syllable contains
     more than one consonant, exclude the starting "Ra" from the list of
     consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is the first consonant, stop.
+      * If the consonant is preceded by the sequence "Halant,ZWJ", stop.
       * If the consonant has a below-base form, tag it as
         `POS_BELOWBASE_CONSONANT`, then move to the previous consonant. 
       * If the consonant has a post-base form, tag it as


### PR DESCRIPTION
This PR incorporates two major fixes:
- It strengthens the base-finding algorithm by adding initial "Ra,Halant" (rather than "initial Ra") as the test and by specifying how to drop out of the base search when a ZWJ/ZWNJ is encountered
- It notes exceptions to final-reordering behavior needed for left-side matras in `mlm2` and `tml2`.

It also improves the formatting of early discussions where the effects of ZWJ/ZWNJ are mentioned in passing by pulling those effects into bulleted points, as is already done elsewhere to denote exceptions and special circumstances that implementations ought to heed.

These are meant to address matters raised in issues #68, #73, and #40. So if you have eyes on those issues, please have a look and flag anything for review that is problematic.