### PR TITLE
Numeral as placeholders

### DIFF
--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -508,13 +508,13 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER` | `NUMBER`
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER` | `MODIFYING_LETTER`
 ```
 
 
@@ -534,7 +534,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -475,13 +475,13 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER` | `NUMBER`
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER` | `MODIFYING_LETTER`
 ```
 
 
@@ -501,7 +501,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -468,7 +468,7 @@ _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER` | `MODIFYING_LETTER`
 ```
 
 

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -462,7 +462,7 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER` | `NUMBER`
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
@@ -488,7 +488,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -518,13 +518,13 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER` | `NUMBER`
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER` | `MODIFYING_LETTER`
 ```
 
 
@@ -544,7 +544,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -819,13 +819,13 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`| `NUMBER` 
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER` | `MODIFYING_LETTER`
 ```
 
 
@@ -845,7 +845,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -479,13 +479,13 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER` | `NUMBER`
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER` | `MODIFYING_LETTER`
 ```
 
 
@@ -505,7 +505,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -514,13 +514,13 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER` | `NUMBER`
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER` | `MODIFYING_LETTER`
 ```
 
 
@@ -540,7 +540,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -518,13 +518,13 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER` | `NUMBER`
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER` | `MODIFYING_LETTER`
 ```
 
 
@@ -544,7 +544,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -433,13 +433,13 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER` | `NUMBER` 
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER`| `MODIFYING_LETTER`
 ```
 
 
@@ -459,7 +459,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -471,13 +471,13 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER` | `NUMBER`
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER` | `MODIFYING_LETTER`
 ```
 
 
@@ -497,7 +497,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -486,13 +486,13 @@ _zwnj_		= `NON_JOINER`
 _matra_		= `VOWEL_DEPENDENT` | `PURE_KILLER`
 _syllablemodifier_	= `SYLLABLE_MODIFIER` | `BINDU` | `VISARGA` | `GEMINATION_MARK`
 _vedicsign_	= `CANTILLATION`
-_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER`
+_placeholder_	= `PLACEHOLDER` | `CONSONANT_PLACEHOLDER` | `NUMBER`
 _dottedcircle_	= `DOTTED_CIRCLE`
 _repha_		= `CONSONANT_PRE_REPHA`
 _consonantmedial_	= `CONSONANT_MEDIAL`
 _symbol_	= `SYMBOL` | `AVAGRAHA`
 _consonantwithstacker_	= `CONSONANT_WITH_STACKER`
-_other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
+_other_		= `OTHER` | `MODIFYING_LETTER`
 ```
 
 
@@ -512,7 +512,10 @@ _other_		= `OTHER` | `NUMBER` | `MODIFYING_LETTER`
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
 > in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces.
+> hyphens and non-breaking spaces. The _placeholder_ identification
+> class also includes numerals, which are commonly used as word
+> substitutes within normal text. Examples include ordinals (e.g.,
+> "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even


### PR DESCRIPTION
For Indic2. Move `NUMBER` into the _placeholder_ class used in syllable identification, and add a note to that effect in case anyone overlooks it. Puts us in line with HarfBuzz treatment and fixes #108.