### PR TITLE
WIP: Improve last-Halant ZW[N]J handling in 4.2

### DIFF
--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -1338,9 +1338,8 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
@@ -1348,6 +1347,30 @@ consonant or syllable base, all conjuncts or ligatures that contain
 the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra reordering](/images/bengali/bengali-matra-position.png)
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> Uniscribe instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 #### 4.3: Reph ####
 

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1252,9 +1252,8 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
@@ -1262,6 +1261,30 @@ consonant or syllable base, all conjuncts or ligatures that contain
 the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra positioning](/images/devanagari/devanagari-matra-position.png)
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> Uniscribe instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 #### 4.3: Reph ####
 

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -1241,9 +1241,8 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
@@ -1251,6 +1250,30 @@ consonant or syllable base, all conjuncts or ligatures that contain
 the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra positioning](/images/gujarati/gujarati-matra-position.png)
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> Uniscribe instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 #### 4.3: Reph ####
 

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -1311,9 +1311,8 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
@@ -1321,6 +1320,30 @@ consonant or syllable base, all conjuncts or ligatures that contain
 the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra positioning](/images/gurmukhi/gurmukhi-matra-position.png)
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> Uniscribe instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 #### 4.3: Reph ####
 

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -1376,13 +1376,13 @@ consonant or syllable base, all conjuncts or ligatures that contain
 the base consonant or syllable base, and all half forms.
 
 > Note: OpenType and Unicode both state that if the syllable includes
-> a ZWJ follows the last "Halant", then the final matra position
-> should be after the ZWJ.
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
 >
 > However, there are several test sequences indicating that
 > Microsoft's Uniscribe shaping engine did not follow this rule (in,
 > at least, Devanagari and Bengali text), and in these circumstances
-> it instead makes the final matra position before the final
+> Uniscribe instead makes the final matra position before the final
 > "Consonant,Halant,ZWJ".
 >
 > Subsequently, the HarfBuzz shaping engine has also followed the same

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -1367,14 +1367,37 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
 the base consonant or syllable base, and all half forms.
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ follows the last "Halant", then the final matra position
+> should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> it instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 #### 4.3: Reph ####
 

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -1371,7 +1371,7 @@ position is defined as:
      final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
-"consonant,Halant" subsequences, but will stop to the left of the base
+"_Consonant_,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
 the base consonant or syllable base, and all half forms.
 

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -1254,9 +1254,8 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
@@ -1266,6 +1265,30 @@ the base consonant or syllable base, and all half forms.
 Kannada does not use pre-base matras, so this step will
 involve no work when processing `<knd2>` text. It is included here in
 order to maintain compatibility with the other Indic scripts.
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> Uniscribe instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 #### 4.3: Reph ####
 

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -1317,9 +1317,8 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "_Consonant_,Halant" subsequences and all glyphs that resulted from a
@@ -1328,6 +1327,30 @@ to the left of the base consonant or syllable base, and all conjuncts
 or ligatures that contain the base consonant or syllable base.
 
 ![Matra positioning](/images/malayalam/malayalam-matra-position.png)
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> Uniscribe instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 #### 4.3: Reph ####
 

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -1303,9 +1303,8 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
@@ -1313,6 +1312,30 @@ consonant or syllable base, all conjuncts or ligatures that contain
 the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra position](/images/oriya/oriya-matra-position.png)
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> Uniscribe instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 
 #### 4.3: Reph ####

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -1100,9 +1100,8 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
@@ -1110,6 +1109,30 @@ consonant or syllable base, all conjuncts or ligatures that contain
 the base consonant or syllable base, and all half forms.
 
 ![Pre-base matra positioning](/images/sinhala/sinhala-matra-position.png)
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> Uniscribe instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 #### 4.3: Reph ####
 

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -1253,9 +1253,8 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences and all glyphs that resulted from a
@@ -1264,6 +1263,30 @@ to the left of the base consonant or syllable base, and all conjuncts
 or ligatures that contain the base consonant or syllable base.
 
 ![Pre-base matra positioning](/images/tamil/tamil-matra-position.png)
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> Uniscribe instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 #### 4.3: Reph ####
 

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -1240,14 +1240,37 @@ position is defined as:
    - after the last standalone "Halant" glyph that comes after the
      matra's starting position and also comes before the main
      consonant.
-   - If a zero-width joiner or a zero-width non-joiner follows this
-     last standalone "Halant", the final matra position is moved to
-     after the joiner or non-joiner.
+   - If a zero-width joiner follows this last standalone "Halant", the
+     final matra position is moved to after the joiner.
 
 This means that the matra will move to the right of all explicit
 "consonant,Halant" subsequences, but will stop to the left of the base
 consonant or syllable base, all conjuncts or ligatures that contain
 the base consonant or syllable base, and all half forms.
+
+> Note: OpenType and Unicode both state that if the syllable includes
+> a ZWJ immediately after the last "Halant", then the final matra
+> position should be after the ZWJ.
+>
+> However, there are several test sequences indicating that
+> Microsoft's Uniscribe shaping engine did not follow this rule (in,
+> at least, Devanagari and Bengali text), and in these circumstances
+> Uniscribe instead makes the final matra position before the final
+> "Consonant,Halant,ZWJ".
+>
+> Subsequently, the HarfBuzz shaping engine has also followed the same
+> pattern. If other shaping engine implementations prefer to maintain
+> maximum compatibility with Uniscribe and HarfBuzz, then they should
+> also follow suit.
+
+> Note: The Microsoft script-development specifications for OpenType
+> shaping also state that if a zero-width non-joiner follows the last
+> standalone "Halant", the final matra position is moved to after the
+> non-joiner. However, it is unneccessary to test for this condition,
+> because a "Halant,ZWNJ" subsequence is, by definition, the end of a
+> syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
+> pre-base dependent vowel.
+
 
 
 #### 4.3: Reph ####


### PR DESCRIPTION
This is a proposed fix for #73, to address the 4.2 left-matra-reordering situation when the last explicit Halant is there due to a ZWJ or (hypothetically) ZWNJ. Uniscribe diverges from the specification and HarfBuzz follows suit so as to preserve compatibility, although it's only a few scripts with documented test-cases.