### PR TITLE
[WIP] Standalone syllables, NBSP, and ZWJ polish

### DIFF
--- a/character-tables/character-tables-bengali.md
+++ b/character-tables/character-tables-bengali.md
@@ -280,27 +280,28 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner is primarily used to prevent the formation of a
-conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The
+sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of
+a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead. The
+sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce the
+first consonant in its standard form, followed by an explicit
+"Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
 "Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
 where an initial "Ra,Halant" sequence without the zero-width joiner
 otherwise would.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 

--- a/character-tables/character-tables-devanagari.md
+++ b/character-tables/character-tables-devanagari.md
@@ -313,27 +313,28 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The
+sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of
+a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead. The
+sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce the
+first consonant in its standard form, followed by an explicit
+"Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
 "Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
 where an initial "Ra,Halant" sequence without the zero-width joiner
 otherwise would.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 

--- a/character-tables/character-tables-gujarati.md
+++ b/character-tables/character-tables-gujarati.md
@@ -281,27 +281,28 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner is primarily used to prevent the formation of a
-conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The
+sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of
+a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead. The
+sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce the
+first consonant in its standard form, followed by an explicit
+"Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
 "Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
 where an initial "Ra,Halant" sequence without the zero-width joiner
 otherwise would.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 

--- a/character-tables/character-tables-gurmukhi.md
+++ b/character-tables/character-tables-gurmukhi.md
@@ -281,27 +281,28 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The
+sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of
+a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead. The
+sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce the
+first consonant in its standard form, followed by an explicit
+"Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
 "Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
 where an initial "Ra,Halant" sequence without the zero-width joiner
 otherwise would.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 

--- a/character-tables/character-tables-kannada.md
+++ b/character-tables/character-tables-kannada.md
@@ -281,27 +281,28 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The
+sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of
+a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead. The
+sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce the
+first consonant in its standard form, followed by an explicit
+"Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
 "Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
 where an initial "Ra,Halant" sequence without the zero-width joiner
 otherwise would.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 

--- a/character-tables/character-tables-malayalam.md
+++ b/character-tables/character-tables-malayalam.md
@@ -281,17 +281,18 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The
+sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of
+a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead. The
+sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce the
+first consonant in its standard form, followed by an explicit
+"Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
 "Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",

--- a/character-tables/character-tables-oriya.md
+++ b/character-tables/character-tables-oriya.md
@@ -281,27 +281,28 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The
+sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of
+a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead. The
+sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce the
+first consonant in its standard form, followed by an explicit
+"Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
 "Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
 where an initial "Ra,Halant" sequence without the zero-width joiner
 otherwise would.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 

--- a/character-tables/character-tables-sinhala.md
+++ b/character-tables/character-tables-sinhala.md
@@ -310,27 +310,23 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+The zero-width joiner (ZWJ) is used to request the subjoined form
+of a consonant. The sequence "Consonant_1,Halant,ZWJ,Consonant_2" is
+used to specify the subjoined form of "Consonant_2".
 
-Note, however, that the "_Consonant_,Halant" subsequence in the above
-example may still trigger a half-forms feature. To prevent the
-application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+A secondary usage of the zero-width joiner is to explicitly request
+the formation of "Reph". An initial "Ra,Halant,ZWJ" sequence should
+produce a "Reph".
 
-A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
-where an initial "Ra,Halant" sequence without the zero-width joiner
-otherwise would.
+The zero-width non-joiner (ZWNJ) is not used in shaping runs of
+Sinhala text. The ZWNJ is referenced below in various regular
+expressions and shaping rules, however, because it is used by other
+Indic scripts.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 

--- a/character-tables/character-tables-tamil.md
+++ b/character-tables/character-tables-tamil.md
@@ -381,29 +381,30 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The
+sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of
+a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead. The
+sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce the
+first consonant in its standard form, followed by an explicit
+"Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
 "Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
 where an initial "Ra,Halant" sequence without the zero-width joiner
 otherwise would.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 
 Tamil text sometimes uses the Latin numerals 2, 3, and 4 in
 superscript or subscript positions to annotate Sanskrit. When used in

--- a/character-tables/character-tables-telugu.md
+++ b/character-tables/character-tables-telugu.md
@@ -281,27 +281,28 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
-"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
-conjunct between the two consonants. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The
+sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of
+a conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. The sequence
-"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
-consonant in its standard form, followed by an explicit "Halant".
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead. The
+sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce the
+first consonant in its standard form, followed by an explicit
+"Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
 "Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
 where an initial "Ra,Halant" sequence without the zero-width joiner
 otherwise would.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 

--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -1243,20 +1243,39 @@ characteristic.
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
 base consonant or syllable base with "half forms" of the consonant
-glyphs. There are three exceptions to the default behavior, for which
+glyphs.
+
+In the most common case, this substitution applies to
+"_Consonant_,Halant" sequences that are followed by another
+_Consonant_.
+
+In addition, a sequence matching "_Consonant_,Halant,ZWJ" must also be
+flagged for potential `half` substitutions.
+
+> Note: The presence of the "ZWJ" at the end of the sequence means
+> that the sequence may match the regular-expression test in stage 1
+> as the end of a syllable, even without being followed by a base
+> consonant or syllable base.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+
+There are three exceptions to the default behavior, for which
 the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been flagged for
     the `rphf` feature earlier, must not be flagged for potential
     `half` substitutions.
 
-  - A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" must be
-    flagged for potential `half` substitutions, even though the presence of the
-    zero-width joiner suppresses the `cjct` feature in a later step.
+  - Non-initial "Ra,Halant" and "Ba,Halant" sequences, which should
+    have been flagged for the `rkrf` or `blwf` features earlier, must
+    not be flagged for potential `half` substitutions.
 
   - A sequence matching "_Consonant_,Halant,ZWNJ,_Consonant_" must not be
     flagged for potential `half` substitutions.
-
 
 ![Half-form formation](/images/bengali/bengali-half-ka.png)
 
@@ -1286,6 +1305,35 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
+
+> Note: The presence of the "ZWJ" in a
+> "_Consonant_,Halant,ZWJ,_Consonant_" sequence should automatically
+> inhibit any `cjct` feature rules from matching the sequence as valid
+> input, and thus prevent the `cjct` substitution from being applied.
+
+> Note: The presence of the "ZWNJ" in a
+> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence means that the
+> "_Consonant_,Halant,ZWNJ" subsequence will match the
+> regular-expression test in stage 1 as the end of a syllable.
+> 
+> Because OpenType shaping features in `<bng2>` are defined as
+> applying only within an individual syllable, this means that the
+> presence of the "ZWNJ" will automatically prevent the application of
+> a `cjct` feature by triggering the identification of a syllable
+> break between the two consonants.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+>
+> Note, also: The presence of the "ZWJ" means that a
+> "_Consonant_,Halant,ZWJ" sequence may match the regular-expression
+> test in stage 1 as the end of a syllable, even without being
+> followed by a base consonant or syllable base. By definition,
+> however, a "_Consonant_,Halant,ZWJ" syllable identified in stage 1
+> cannot also include a "_Consonant_" after the ZWJ.
 
 The font's GSUB rules might be implemented so that `cjct`
 substitutions apply to half-form consonants; therefore, this feature

--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -78,7 +78,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -382,7 +382,7 @@ From the shaping engine's perspective, the main distinction between a
 syllable with a base consonant and a syllable with an
 independent-vowel base is that a syllable with an independent-vowel
 base is less likely to include additional consonants in special forms
-and less likely to include depedendent vowel signs
+and less likely to include dependent vowel signs
 (matras). Therefore, in the common case, vowel-based syllables may
 involve less reordering, substitution feature applications, and other
 processing than consonant-based syllables.
@@ -611,7 +611,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -1067,7 +1067,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 
@@ -1424,7 +1424,7 @@ the base consonant or syllable base, and all half forms.
 > Note: The Microsoft script-development specifications for OpenType
 > shaping also state that if a zero-width non-joiner follows the last
 > standalone "Halant", the final matra position is moved to after the
-> non-joiner. However, it is unneccessary to test for this condition,
+> non-joiner. However, it is unnecessary to test for this condition,
 > because a "Halant,ZWNJ" subsequence is, by definition, the end of a
 > syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
 > pre-base dependent vowel.
@@ -1697,7 +1697,7 @@ the `<beng>` script tag and it is known that the font in use supports
 only the `<bng2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant or syllable base when it is
+below-base consonants occurring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -250,8 +250,8 @@ text syllables may also use other characters, such as hyphens or dashes,
 in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. 
 
   - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
     formation of a conjunct between the two consonants. 
@@ -259,7 +259,7 @@ from a "_Consonant_,Halant,_Consonant_" sequence.
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead.
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead.
 
   - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
     the first consonant in its standard form, followed by an explicit
@@ -272,12 +272,12 @@ A secondary usage of the zero-width joiner is to prevent the formation of
     even where an initial "Ra,Halant" sequence without the zero-width
     joiner would otherwise produce a "Reph".
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 
 In addition to general punctuation, runs of Bengali text often use the
 danda (`U+0964`) and double danda (`U+0965`) punctuation marks from

--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -533,11 +533,14 @@ _other_		= `OTHER` | `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -607,6 +610,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-default.md
+++ b/opentype-shaping-default.md
@@ -40,7 +40,7 @@ Greek, Armenian, Georgian, Ethiopic, Cherokee, Tifinagh, and many others.
 Many of these scripts support diacritics and other **marks**. Unicode may
 contain **precomposed** mark-and-base codepoints for some or all
 combinations of marks and base letters in the script. For combinations
-without a codepoint, the desired form can be acheived by following the
+without a codepoint, the desired form can be achieved by following the
 **base** letter with a **combining mark** codepoint. 
 
 The primary concern for the shaping engine is processing the text run into
@@ -206,7 +206,7 @@ user interfaces.
 
 The `clig` feature substitutes optional ligatures that are on by
 default, but which are activated only in certain
-contexts. Substitutions made by clig may be disabled by
+contexts. Substitutions made by `clig` may be disabled by
 application-level user interfaces. 
 
 The `liga` feature substitutes standard, optional ligatures that are on

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -500,11 +500,14 @@ _other_		= `OTHER` | `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -574,6 +577,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1219,7 +1219,7 @@ A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
 
 > Note: The presence of the "ZWJ" in a
-> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence should automatically
+> "_Consonant_,Halant,ZWJ,_Consonant_" sequence should automatically
 > inhibit any `cjct` feature rules from matching the sequence as valid
 > input, and thus prevent the `cjct` substitution from being applied.
 

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1218,18 +1218,18 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
 
-> Note: The presence of the "ZWNJ" at the end of the sequence means
+> Note: The presence of the "ZWJ" at the end of the sequence means
 > that the sequence will match the regular-expression test in stage 1
 > as the end of a syllable.
 > 
 > Because OpenType shaping features in `<dev2`> are defined as
 > applying only within an individual syllable, this means that the
-> presence of the "ZWNJ" will automatically prevent the application of
+> presence of the "ZWJ" will automatically prevent the application of
 > a `cjct` feature by triggering the identification of a syllable
 > break between the two consonants.
 >
 > The fact that the regular-expression tests identify a syllable break
-> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
 > shaping and Unicode encoding, however, and might not have any
 > significance with regard to the definition of syllables used in the
 > language or orthography of the text.

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1161,7 +1161,7 @@ flagged for potential `half` substitutions.
 
 > Note: The presence of the "ZWJ" at the end of the sequence means
 > that the sequence may match the regular-expression test in stage 1
-> the end of a syllable, even without being followed by a base
+> as the end of a syllable, even without being followed by a base
 > consonant or syllable base.
 >
 > The fact that the regular-expression tests identify a syllable break
@@ -1218,21 +1218,34 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
 
-> Note: The presence of the "ZWJ" at the end of the sequence means
-> that the sequence will match the regular-expression test in stage 1
-> as the end of a syllable.
+> Note: The presence of the "ZWJ" in a
+> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence should automatically
+> inhibit any `cjct` feature rules from matching the sequence as valid
+> input, and thus prevent the `cjct` substitution from being applied.
+
+> Note: The presence of the "ZWNJ" in a
+> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence means that the
+> "_Consonant_,Halant,ZWNJ" subsequence will match the
+> regular-expression test in stage 1 as the end of a syllable.
 > 
 > Because OpenType shaping features in `<dev2`> are defined as
 > applying only within an individual syllable, this means that the
-> presence of the "ZWJ" will automatically prevent the application of
+> presence of the "ZWNJ" will automatically prevent the application of
 > a `cjct` feature by triggering the identification of a syllable
 > break between the two consonants.
 >
 > The fact that the regular-expression tests identify a syllable break
-> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
 > shaping and Unicode encoding, however, and might not have any
 > significance with regard to the definition of syllables used in the
 > language or orthography of the text.
+>
+> Note, also: The presence of the "ZWJ" means that a
+> "_Consonant_,Halant,ZWJ" sequence may match the regular-expression
+> test in stage 1 as the end of a syllable, even without being
+> followed by a base consonant or syllable base. By definition,
+> however, a "_Consonant_,Halant,ZWJ" syllable identified in stage 1
+> cannot also include a "_Consonant_" after the ZWJ.
 
 The font's GSUB rules might be implemented so that `cjct`
 substitutions apply to half-form consonants; therefore, this feature

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1140,7 +1140,22 @@ characteristic.
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
 base consonant or syllable base with "half forms" of the consonant
-glyphs. There are four exceptions to the default behavior, for which
+glyphs. 
+
+In addition, a sequence matching "_Consonant_,Halant,ZWJ" must also be
+flagged for potential `half` substitutions.
+
+> Note: The presence of the "ZWJ" at the end of the sequence means
+> that the sequence will match the regular-expression test in stage 1
+> even without being followed by a base consonant or syllable base. 
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+
+There are three exceptions to the default behavior, for which
 the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been flagged for
@@ -1150,10 +1165,6 @@ the shaping engine must test:
   - Non-initial "Ra,Halant" sequences, which should have been flagged
     for the `rkrf` or `blwf` features earlier, must not be flagged for
     potential `half` substitutions.
-  
-  - A sequence matching "_Consonant_,Halant,ZWJ" must be
-    flagged for potential `half` substitutions, even though the presence of the
-    zero-width joiner suppresses the `cjct` feature in a later step.
 
   - A sequence matching "_Consonant_,Halant,ZWNJ,_Consonant_" must not be
     flagged for potential `half` substitutions.
@@ -1191,6 +1202,22 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
+
+> Note: The presence of the "ZWJ" at the end of the sequence means
+> that the sequence will match the regular-expression test in stage 1
+> as the end of a syllable.
+> 
+> Because OpenType shaping features in `<dev2`> are defined as
+> applying only within an individual syllable, this means that the
+> presence of the "ZWJ" will automatically prevent the application of
+> a `cjct` feature by triggering the identification of a syllable
+> break between the two consonants.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
 
 The font's GSUB rules might be implemented so that `cjct`
 substitutions apply to half-form consonants; therefore, this feature

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1150,13 +1150,17 @@ characteristic.
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
 base consonant or syllable base with "half forms" of the consonant
-glyphs. 
+glyphs.
+
+In the most common case, this substitution applies to
+"_Consonant_,Halant" sequences that are followed by another
+_Consonant_.
 
 In addition, a sequence matching "_Consonant_,Halant,ZWJ" must also be
 flagged for potential `half` substitutions.
 
 > Note: The presence of the "ZWJ" at the end of the sequence means
-> that the sequence will match the regular-expression test in stage 1
+> that the sequence may match the regular-expression test in stage 1
 > the end of a syllable, even without being followed by a base
 > consonant or syllable base.
 >
@@ -1214,18 +1218,18 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
 
-> Note: The presence of the "ZWJ" at the end of the sequence means
+> Note: The presence of the "ZWNJ" at the end of the sequence means
 > that the sequence will match the regular-expression test in stage 1
 > as the end of a syllable.
 > 
 > Because OpenType shaping features in `<dev2`> are defined as
 > applying only within an individual syllable, this means that the
-> presence of the "ZWJ" will automatically prevent the application of
+> presence of the "ZWNJ" will automatically prevent the application of
 > a `cjct` feature by triggering the identification of a syllable
 > break between the two consonants.
 >
 > The fact that the regular-expression tests identify a syllable break
-> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
 > shaping and Unicode encoding, however, and might not have any
 > significance with regard to the definition of syllables used in the
 > language or orthography of the text.

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -74,7 +74,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -367,7 +367,7 @@ From the shaping engine's perspective, the main distinction between a
 syllable with a base consonant and a syllable with an
 independent-vowel base is that a syllable with an independent-vowel
 base is less likely to include additional consonants in special forms
-and less likely to include depedendent vowel signs
+and less likely to include dependent vowel signs
 (matras). Therefore, in the common case, vowel-based syllables may
 involve less reordering, substitution feature applications, and other
 processing than consonant-based syllables.
@@ -578,7 +578,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -987,7 +987,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 
@@ -1335,7 +1335,7 @@ the base consonant or syllable base, and all half forms.
 > Note: The Microsoft script-development specifications for OpenType
 > shaping also state that if a zero-width non-joiner follows the last
 > standalone "Halant", the final matra position is moved to after the
-> non-joiner. However, it is unneccessary to test for this condition,
+> non-joiner. However, it is unnecessary to test for this condition,
 > because a "Halant,ZWNJ" subsequence is, by definition, the end of a
 > syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
 > pre-base dependent vowel.
@@ -1591,7 +1591,7 @@ the `<deva>` script tag and it is known that the font in use supports
 only the `<dev2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant or syllable base when it is
+below-base consonants occurring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1157,7 +1157,8 @@ flagged for potential `half` substitutions.
 
 > Note: The presence of the "ZWJ" at the end of the sequence means
 > that the sequence will match the regular-expression test in stage 1
-> even without being followed by a base consonant or syllable base. 
+> the end of a syllable, even without being followed by a base
+> consonant or syllable base.
 >
 > The fact that the regular-expression tests identify a syllable break
 > after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1151,7 +1151,7 @@ the shaping engine must test:
     for the `rkrf` or `blwf` features earlier, must not be flagged for
     potential `half` substitutions.
   
-  - A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" must be
+  - A sequence matching "_Consonant_,Halant,ZWJ" must be
     flagged for potential `half` substitutions, even though the presence of the
     zero-width joiner suppresses the `cjct` feature in a later step.
 

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -241,8 +241,8 @@ text syllables may also use other characters, such as hyphens or dashes,
 in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. 
 
   - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
     formation of a conjunct between the two consonants. 
@@ -250,7 +250,7 @@ from a "_Consonant_,Halant,_Consonant_" sequence.
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead.
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead.
 
   - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
     the first consonant in its standard form, followed by an explicit
@@ -263,12 +263,12 @@ A secondary usage of the zero-width joiner is to prevent the formation of
     even where an initial "Ra,Halant" sequence without the zero-width
     joiner would otherwise produce a "Reph".
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 
 
 

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -1228,7 +1228,7 @@ A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 > "_Consonant_,Halant,ZWNJ" subsequence will match the
 > regular-expression test in stage 1 as the end of a syllable.
 > 
-> Because OpenType shaping features in `<dev2`> are defined as
+> Because OpenType shaping features in `<dev2>` are defined as
 > applying only within an individual syllable, this means that the
 > presence of the "ZWNJ" will automatically prevent the application of
 > a `cjct` feature by triggering the identification of a syllable

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -1141,7 +1141,27 @@ characteristic.
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
 base consonant or syllable base with "half forms" of the consonant
-glyphs. There are four exceptions to the default behavior, for which
+glyphs.
+
+In the most common case, this substitution applies to
+"_Consonant_,Halant" sequences that are followed by another
+_Consonant_.
+
+In addition, a sequence matching "_Consonant_,Halant,ZWJ" must also be
+flagged for potential `half` substitutions.
+
+> Note: The presence of the "ZWJ" at the end of the sequence means
+> that the sequence may match the regular-expression test in stage 1
+> as the end of a syllable, even without being followed by a base
+> consonant or syllable base.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+
+There are three exceptions to the default behavior, for which
 the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been flagged for
@@ -1151,10 +1171,6 @@ the shaping engine must test:
   - Non-initial "Ra,Halant" sequences, which should have been flagged
     for the `rkrf` or `blwf` features earlier, must not be flagged for
     potential `half` substitutions.
-  
-  - A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" must be
-    flagged for potential `half` substitutions, even though the presence of the
-    zero-width joiner suppresses the `cjct` feature in a later step.
 
   - A sequence matching "_Consonant_,Halant,ZWNJ,_Consonant_" must not be
     flagged for potential `half` substitutions.
@@ -1190,6 +1206,35 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
+
+> Note: The presence of the "ZWJ" in a
+> "_Consonant_,Halant,ZWJ,_Consonant_" sequence should automatically
+> inhibit any `cjct` feature rules from matching the sequence as valid
+> input, and thus prevent the `cjct` substitution from being applied.
+
+> Note: The presence of the "ZWNJ" in a
+> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence means that the
+> "_Consonant_,Halant,ZWNJ" subsequence will match the
+> regular-expression test in stage 1 as the end of a syllable.
+> 
+> Because OpenType shaping features in `<gjr2>` are defined as
+> applying only within an individual syllable, this means that the
+> presence of the "ZWNJ" will automatically prevent the application of
+> a `cjct` feature by triggering the identification of a syllable
+> break between the two consonants.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+>
+> Note, also: The presence of the "ZWJ" means that a
+> "_Consonant_,Halant,ZWJ" sequence may match the regular-expression
+> test in stage 1 as the end of a syllable, even without being
+> followed by a base consonant or syllable base. By definition,
+> however, a "_Consonant_,Halant,ZWJ" syllable identified in stage 1
+> cannot also include a "_Consonant_" after the ZWJ.
 
 The font's GSUB rules might be implemented so that `cjct`
 substitutions apply to half-form consonants; therefore, this feature

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -487,11 +487,14 @@ _other_		= `OTHER` | `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -561,6 +564,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -236,8 +236,8 @@ text syllables may also use other characters, such as hyphens or dashes,
 in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence.
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence.
 
   - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
     formation of a conjunct between the two consonants. 
@@ -245,7 +245,7 @@ from a "_Consonant_,Halant,_Consonant_" sequence.
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead.
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead.
 
   - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
     the first consonant in its standard form, followed by an explicit
@@ -258,12 +258,12 @@ A secondary usage of the zero-width joiner is to prevent the formation of
     even where an initial "Ra,Halant" sequence without the zero-width
     joiner would otherwise produce a "Reph".
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 
 
 

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -70,7 +70,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -363,7 +363,7 @@ From the shaping engine's perspective, the main distinction between a
 syllable with a base consonant and a syllable with an
 independent-vowel base is that a syllable with an independent-vowel
 base is less likely to include additional consonants in special forms
-and less likely to include depedendent vowel signs
+and less likely to include dependent vowel signs
 (matras). Therefore, in the common case, vowel-based syllables may
 involve less reordering, substitution feature applications, and other
 processing than consonant-based syllables.
@@ -565,7 +565,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -980,7 +980,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 
@@ -1324,7 +1324,7 @@ the base consonant or syllable base, and all half forms.
 > Note: The Microsoft script-development specifications for OpenType
 > shaping also state that if a zero-width non-joiner follows the last
 > standalone "Halant", the final matra position is moved to after the
-> non-joiner. However, it is unneccessary to test for this condition,
+> non-joiner. However, it is unnecessary to test for this condition,
 > because a "Halant,ZWNJ" subsequence is, by definition, the end of a
 > syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
 > pre-base dependent vowel.
@@ -1573,7 +1573,7 @@ the `<gujr>` script tag and it is known that the font in use supports
 only the `<gjr2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant or syllable base when it is
+below-base consonants occurring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -1207,17 +1207,37 @@ characteristic.
 #### 3.9: half ####
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
-base consonant or syllable base with "half forms" of the consonant glyphs. There are
-three exceptions to the default behavior, for which the shaping engine
-must test:
+base consonant or syllable base with "half forms" of the consonant
+glyphs.
+
+In the most common case, this substitution applies to
+"_Consonant_,Halant" sequences that are followed by another
+_Consonant_.
+
+In addition, a sequence matching "_Consonant_,Halant,ZWJ" must also be
+flagged for potential `half` substitutions.
+
+> Note: The presence of the "ZWJ" at the end of the sequence means
+> that the sequence may match the regular-expression test in stage 1
+> as the end of a syllable, even without being followed by a base
+> consonant or syllable base.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+
+There are three exceptions to the default behavior, for which
+the shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been flagged for
     the `rphf` feature earlier, must not be flagged for potential
     `half` substitutions.
 
-  - A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" must be
-    flagged for potential `half` substitutions, even though the presence of the
-    zero-width joiner suppresses the `cjct` feature in a later step.
+  - Non-initial "Ra,Halant", "Ha,Halant", and "Va,Halant" sequences,
+    which should have been flagged for the `rkrf` or `blwf` features
+    earlier, must not be flagged for potential `half` substitutions.
 
   - A sequence matching "_Consonant_,Halant,ZWNJ,_Consonant_" must not be
     flagged for potential `half` substitutions.
@@ -1258,6 +1278,35 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
+
+> Note: The presence of the "ZWJ" in a
+> "_Consonant_,Halant,ZWJ,_Consonant_" sequence should automatically
+> inhibit any `cjct` feature rules from matching the sequence as valid
+> input, and thus prevent the `cjct` substitution from being applied.
+
+> Note: The presence of the "ZWNJ" in a
+> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence means that the
+> "_Consonant_,Halant,ZWNJ" subsequence will match the
+> regular-expression test in stage 1 as the end of a syllable.
+> 
+> Because OpenType shaping features in `<gur2>` are defined as
+> applying only within an individual syllable, this means that the
+> presence of the "ZWNJ" will automatically prevent the application of
+> a `cjct` feature by triggering the identification of a syllable
+> break between the two consonants.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+>
+> Note, also: The presence of the "ZWJ" means that a
+> "_Consonant_,Halant,ZWJ" sequence may match the regular-expression
+> test in stage 1 as the end of a syllable, even without being
+> followed by a base consonant or syllable base. By definition,
+> however, a "_Consonant_,Halant,ZWJ" syllable identified in stage 1
+> cannot also include a "_Consonant_" after the ZWJ.
 
 The font's GSUB rules might be implemented so that `cjct`
 substitutions apply to half-form consonants; therefore, this feature

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -75,7 +75,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -407,7 +407,7 @@ From the shaping engine's perspective, the main distinction between a
 syllable with a base consonant and a syllable with an
 independent-vowel base is that a syllable with an independent-vowel
 base is less likely to include additional consonants in special forms
-and less likely to include depedendent vowel signs
+and less likely to include dependent vowel signs
 (matras). Therefore, in the common case, vowel-based syllables may
 involve less reordering, substitution feature applications, and other
 processing than consonant-based syllables.
@@ -621,7 +621,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -1046,7 +1046,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 
@@ -1398,7 +1398,7 @@ the base consonant or syllable base, and all half forms.
 > Note: The Microsoft script-development specifications for OpenType
 > shaping also state that if a zero-width non-joiner follows the last
 > standalone "Halant", the final matra position is moved to after the
-> non-joiner. However, it is unneccessary to test for this condition,
+> non-joiner. However, it is unnecessary to test for this condition,
 > because a "Halant,ZWNJ" subsequence is, by definition, the end of a
 > syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
 > pre-base dependent vowel.
@@ -1650,7 +1650,7 @@ the `<guru>` script tag and it is known that the font in use supports
 only the `<gur2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant or syllable base when it is
+below-base consonants occurring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -274,8 +274,8 @@ text syllables may also use other characters, such as hyphens or dashes,
 in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence.
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence.
 
   - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
     formation of a conjunct between the two consonants. 
@@ -283,7 +283,7 @@ from a "_Consonant_,Halant,_Consonant_" sequence.
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead.
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead.
 
   - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
     the first consonant in its standard form, followed by an explicit
@@ -301,12 +301,12 @@ A secondary usage of the zero-width joiner is to prevent the formation of
 > shaping engines must test for it in order to provide the
 > functionality if it is implemented.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 
 In addition to general punctuation, runs of Gurmukhi text often use the
 danda (`U+0964`) and double danda (`U+0965`) punctuation marks from

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -543,11 +543,14 @@ _other_		= `OTHER` | `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -617,6 +620,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-hangul.md
+++ b/opentype-shaping-hangul.md
@@ -47,7 +47,7 @@ vertically, top to bottom.
 
 ## Terminology ##
 
-OpenType shaping uuses a standard set of terms for elements of the
+OpenType shaping uses a standard set of terms for elements of the
 Hangul script. The terms used colloquially in any particular language
 or country may vary, however, potentially causing confusion.
 

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -120,7 +120,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -922,7 +922,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -1249,7 +1249,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -844,11 +844,14 @@ _other_		= `OTHER` | `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -918,6 +921,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -504,11 +504,14 @@ _other_		= `OTHER` | `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -578,6 +581,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -78,7 +78,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -582,7 +582,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -1020,7 +1020,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 
@@ -1339,7 +1339,7 @@ order to maintain compatibility with the other Indic scripts.
 > Note: The Microsoft script-development specifications for OpenType
 > shaping also state that if a zero-width non-joiner follows the last
 > standalone "Halant", the final matra position is moved to after the
-> non-joiner. However, it is unneccessary to test for this condition,
+> non-joiner. However, it is unnecessary to test for this condition,
 > because a "Halant,ZWNJ" subsequence is, by definition, the end of a
 > syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
 > pre-base dependent vowel.

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -255,8 +255,8 @@ text syllables may also use other characters, such as hyphens or dashes,
 in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence. 
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. 
 
   - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
     formation of a conjunct between the two consonants. 
@@ -264,7 +264,7 @@ from a "_Consonant_,Halant,_Consonant_" sequence.
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead. 
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead. 
 
   - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
     the first consonant in its standard form, followed by an explicit
@@ -277,12 +277,12 @@ A secondary usage of the zero-width joiner is to prevent the formation of
     even where an initial "Ra,Halant" sequence without the zero-width
     joiner would otherwise produce a "Reph".
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 
 In addition to general punctuation, runs of Kannada text often use the
 danda (`U+0964`) and double danda (`U+0965`) punctuation marks from

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -1165,16 +1165,32 @@ form.
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
 base consonant or syllable base with "half forms" of the consonant
-glyphs. There arethree exceptions to the default behavior, for which
-the shaping engine must test:
+glyphs.
+
+In the most common case, this substitution applies to
+"_Consonant_,Halant" sequences that are followed by another
+_Consonant_.
+
+In addition, a sequence matching "_Consonant_,Halant,ZWJ" must also be
+flagged for potential `half` substitutions.
+
+> Note: The presence of the "ZWJ" at the end of the sequence means
+> that the sequence may match the regular-expression test in stage 1
+> as the end of a syllable, even without being followed by a base
+> consonant or syllable base.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+
+There are two exceptions to the default behavior, for which the
+shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been flagged for
     the `rphf` feature earlier, must not be flagged for potential
     `half` substitutions.
-
-  - A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" must be
-    flagged for potential `half` substitutions, even though the presence of the
-    zero-width joiner suppresses the `cjct` feature in a later step.
 
   - A sequence matching "_Consonant_,Halant,ZWNJ,_Consonant_" must not be
     flagged for potential `half` substitutions.
@@ -1200,6 +1216,35 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
+
+> Note: The presence of the "ZWJ" in a
+> "_Consonant_,Halant,ZWJ,_Consonant_" sequence should automatically
+> inhibit any `cjct` feature rules from matching the sequence as valid
+> input, and thus prevent the `cjct` substitution from being applied.
+
+> Note: The presence of the "ZWNJ" in a
+> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence means that the
+> "_Consonant_,Halant,ZWNJ" subsequence will match the
+> regular-expression test in stage 1 as the end of a syllable.
+> 
+> Because OpenType shaping features in `<knd2>` are defined as
+> applying only within an individual syllable, this means that the
+> presence of the "ZWNJ" will automatically prevent the application of
+> a `cjct` feature by triggering the identification of a syllable
+> break between the two consonants.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+>
+> Note, also: The presence of the "ZWJ" means that a
+> "_Consonant_,Halant,ZWJ" sequence may match the regular-expression
+> test in stage 1 as the end of a syllable, even without being
+> followed by a base consonant or syllable base. By definition,
+> however, a "_Consonant_,Halant,ZWJ" syllable identified in stage 1
+> cannot also include a "_Consonant_" after the ZWJ.
 
 The font's GSUB rules might be implemented so that `cjct`
 substitutions apply to half-form consonants; therefore, this feature

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -71,7 +71,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -343,7 +343,7 @@ characteristics include:
   - `BASE_POS_LAST` = The base consonant of a syllable is the last
      consonant, not counting any special final-consonant forms.
 
-  - `REPH_POS_AFTER_MAIN` = "Reph" is ordered after the sylable base.
+  - `REPH_POS_AFTER_MAIN` = "Reph" is ordered after the syllable base.
 
   - `REPH_MODE_LOGICAL_REPHA` = "Reph" is encoded as its own Unicode
      codepoint ("Repha"), but it must still be reordered. 
@@ -395,7 +395,7 @@ From the shaping engine's perspective, the main distinction between a
 syllable with a base consonant and a syllable with an
 independent-vowel base is that a syllable with an independent-vowel
 base is less likely to include additional consonants in special forms
-and less likely to include depedendent vowel signs
+and less likely to include dependent vowel signs
 (matras). Therefore, in the common case, vowel-based syllables may
 involve less reordering, substitution feature applications, and other
 processing than consonant-based syllables.
@@ -617,7 +617,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -1038,7 +1038,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 
@@ -1401,7 +1401,7 @@ or ligatures that contain the base consonant or syllable base.
 > Note: The Microsoft script-development specifications for OpenType
 > shaping also state that if a zero-width non-joiner follows the last
 > standalone "Halant", the final matra position is moved to after the
-> non-joiner. However, it is unneccessary to test for this condition,
+> non-joiner. However, it is unnecessary to test for this condition,
 > because a "Halant,ZWNJ" subsequence is, by definition, the end of a
 > syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
 > pre-base dependent vowel.
@@ -1624,7 +1624,7 @@ the `<mlym>` script tag and it is known that the font in use supports
 only the `<mlm2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant or syllable base when it is
+below-base consonants occurring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -263,8 +263,8 @@ text syllables may also use other characters, such as hyphens or dashes,
 in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence.
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence.
 
   - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
     formation of a conjunct between the two consonants. 
@@ -272,7 +272,7 @@ from a "_Consonant_,Halant,_Consonant_" sequence.
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead.
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead.
 
   - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
     the first consonant in its standard form, followed by an explicit
@@ -285,12 +285,12 @@ A secondary usage of the zero-width joiner is to prevent the formation of
     even where an initial "Ra,Halant" sequence without the zero-width
     joiner would otherwise produce a "Reph".
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_". 
 
 In addition to general punctuation, runs of Malayalam text often use the
 danda (`U+0964`) and double danda (`U+0965`) punctuation marks from

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -1212,16 +1212,32 @@ characteristic.
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
 base consonant or syllable base with "half forms" of the consonant
-glyphs. There are three exceptions to the default behavior, for which
-the shaping engine must test:
+glyphs.
+
+In the most common case, this substitution applies to
+"_Consonant_,Halant" sequences that are followed by another
+_Consonant_.
+
+In addition, a sequence matching "_Consonant_,Halant,ZWJ" must also be
+flagged for potential `half` substitutions.
+
+> Note: The presence of the "ZWJ" at the end of the sequence means
+> that the sequence may match the regular-expression test in stage 1
+> as the end of a syllable, even without being followed by a base
+> consonant or syllable base.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+
+There are two exceptions to the default behavior, for which the
+shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been flagged for
     the `rphf` feature earlier, must not be flagged for potential
     `half` substitutions.
-
-  - A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" must be
-    flagged for potential `half` substitutions, even though the presence of the
-    zero-width joiner suppresses the `cjct` feature in a later step.
 
   - A sequence matching "_Consonant_,Halant,ZWNJ,_Consonant_" must not be
     flagged for potential `half` substitutions.
@@ -1260,6 +1276,35 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
+
+> Note: The presence of the "ZWJ" in a
+> "_Consonant_,Halant,ZWJ,_Consonant_" sequence should automatically
+> inhibit any `cjct` feature rules from matching the sequence as valid
+> input, and thus prevent the `cjct` substitution from being applied.
+
+> Note: The presence of the "ZWNJ" in a
+> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence means that the
+> "_Consonant_,Halant,ZWNJ" subsequence will match the
+> regular-expression test in stage 1 as the end of a syllable.
+> 
+> Because OpenType shaping features in `<mlm2>` are defined as
+> applying only within an individual syllable, this means that the
+> presence of the "ZWNJ" will automatically prevent the application of
+> a `cjct` feature by triggering the identification of a syllable
+> break between the two consonants.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+>
+> Note, also: The presence of the "ZWJ" means that a
+> "_Consonant_,Halant,ZWJ" sequence may match the regular-expression
+> test in stage 1 as the end of a syllable, even without being
+> followed by a base consonant or syllable base. By definition,
+> however, a "_Consonant_,Halant,ZWJ" syllable identified in stage 1
+> cannot also include a "_Consonant_" after the ZWJ.
 
 The font's GSUB rules might be implemented so that `cjct`
 substitutions apply to half-form consonants; therefore, this feature

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -539,11 +539,14 @@ _other_		= `OTHER` | `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -613,6 +616,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-mongolian.md
+++ b/opentype-shaping-mongolian.md
@@ -636,7 +636,7 @@ of bases and marks with precomposed base-and-mark glyphs.
 > account for necessary mark-reordering adjustments conducted in the
 > next stage.
 > 
-> Nevertheless, when the active font uses `mset` substituions, the
+> Nevertheless, when the active font uses `mset` substitutions, the
 > shaping engine must deal with the situation gracefully.
 
 ### 6. Mark reordering ###

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -234,8 +234,8 @@ text syllables may also use other characters, such as hyphens or dashes,
 in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence.
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence.
 
   - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
     formation of a conjunct between the two consonants. 
@@ -243,7 +243,7 @@ from a "_Consonant_,Halant,_Consonant_" sequence.
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead.
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead.
 
   - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
     the first consonant in its standard form, followed by an explicit
@@ -256,12 +256,12 @@ A secondary usage of the zero-width joiner is to prevent the formation of
     even where an initial "Ra,Halant" sequence without the zero-width
     joiner would otherwise produce a "Reph".
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 
 In addition to general punctuation, runs of Oriya text often use the
 danda (`U+0964`) and double danda (`U+0965`) punctuation marks from

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -544,11 +544,14 @@ _other_		= `OTHER` | `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -618,6 +621,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -1215,16 +1215,32 @@ characteristic.
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
 base consonant or syllable base with "half forms" of the consonant
-glyphs. There are three exceptions to the default behavior, for which
-the shaping engine must test:
+glyphs.
+
+In the most common case, this substitution applies to
+"_Consonant_,Halant" sequences that are followed by another
+_Consonant_.
+
+In addition, a sequence matching "_Consonant_,Halant,ZWJ" must also be
+flagged for potential `half` substitutions.
+
+> Note: The presence of the "ZWJ" at the end of the sequence means
+> that the sequence may match the regular-expression test in stage 1
+> as the end of a syllable, even without being followed by a base
+> consonant or syllable base.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+
+There are two exceptions to the default behavior, for which the
+shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been flagged for
     the `rphf` feature earlier, must not be flagged for potential
     `half` substitutions.
-
-  - A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" must be
-    flagged for potential `half` substitutions, even though the presence of the
-    zero-width joiner suppresses the `cjct` feature in a later step.
 
   - A sequence matching "_Consonant_,Halant,ZWNJ,_Consonant_" must not be
     flagged for potential `half` substitutions.
@@ -1251,6 +1267,35 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
+
+> Note: The presence of the "ZWJ" in a
+> "_Consonant_,Halant,ZWJ,_Consonant_" sequence should automatically
+> inhibit any `cjct` feature rules from matching the sequence as valid
+> input, and thus prevent the `cjct` substitution from being applied.
+
+> Note: The presence of the "ZWNJ" in a
+> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence means that the
+> "_Consonant_,Halant,ZWNJ" subsequence will match the
+> regular-expression test in stage 1 as the end of a syllable.
+> 
+> Because OpenType shaping features in `<ory2>` are defined as
+> applying only within an individual syllable, this means that the
+> presence of the "ZWNJ" will automatically prevent the application of
+> a `cjct` feature by triggering the identification of a syllable
+> break between the two consonants.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+>
+> Note, also: The presence of the "ZWJ" means that a
+> "_Consonant_,Halant,ZWJ" sequence may match the regular-expression
+> test in stage 1 as the end of a syllable, even without being
+> followed by a base consonant or syllable base. By definition,
+> however, a "_Consonant_,Halant,ZWJ" syllable identified in stage 1
+> cannot also include a "_Consonant_" after the ZWJ.
 
 The font's GSUB rules might be implemented so that `cjct`
 substitutions apply to half-form consonants; therefore, this feature

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -70,7 +70,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -364,7 +364,7 @@ From the shaping engine's perspective, the main distinction between a
 syllable with a base consonant and a syllable with an
 independent-vowel base is that a syllable with an independent-vowel
 base is less likely to include additional consonants in special forms
-and less likely to include depedendent vowel signs
+and less likely to include dependent vowel signs
 (matras). Therefore, in the common case, vowel-based syllables may
 involve less reordering, substitution feature applications, and other
 processing than consonant-based syllables.
@@ -622,7 +622,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -1065,7 +1065,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 
@@ -1386,7 +1386,7 @@ the base consonant or syllable base, and all half forms.
 > Note: The Microsoft script-development specifications for OpenType
 > shaping also state that if a zero-width non-joiner follows the last
 > standalone "Halant", the final matra position is moved to after the
-> non-joiner. However, it is unneccessary to test for this condition,
+> non-joiner. However, it is unnecessary to test for this condition,
 > because a "Halant,ZWNJ" subsequence is, by definition, the end of a
 > syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
 > pre-base dependent vowel.
@@ -1609,7 +1609,7 @@ the `<orya>` script tag and it is known that the font in use supports
 only the `<ory2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant or syllable base when it is
+below-base consonants occurring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -462,11 +462,14 @@ _other_		= `OTHER`| `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -536,6 +539,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -61,7 +61,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example. In the Sinhalese language, the Reph form is known as _repaya_.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -350,7 +350,7 @@ From the shaping engine's perspective, the main distinction between a
 syllable with a base consonant and a syllable with an
 independent-vowel base is that a syllable with an independent-vowel
 base is less likely to include additional consonants in special forms
-and less likely to include depedendent vowel signs
+and less likely to include dependent vowel signs
 (matras). Therefore, in the common case, vowel-based syllables may
 involve less reordering, substitution feature applications, and other
 processing than consonant-based syllables.
@@ -540,7 +540,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -893,7 +893,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 
@@ -1142,7 +1142,7 @@ the base consonant or syllable base, and all half forms.
 > Note: The Microsoft script-development specifications for OpenType
 > shaping also state that if a zero-width non-joiner follows the last
 > standalone "Halant", the final matra position is moved to after the
-> non-joiner. However, it is unneccessary to test for this condition,
+> non-joiner. However, it is unnecessary to test for this condition,
 > because a "Halant,ZWNJ" subsequence is, by definition, the end of a
 > syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
 > pre-base dependent vowel.

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -228,8 +228,8 @@ text syllables may also use other characters, such as hyphens or dashes,
 in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
-In other Indic scripts, the zero-width joiner is used to prevent the
-formation of conjuncts and to suppress the formation of "Reph".
+In other Indic scripts, the zero-width joiner (ZWJ) is used to prevent
+the formation of conjuncts and to suppress the formation of "Reph".
 
 Sinhala, however, differs considerably in its use of "ZWJ".
 
@@ -241,13 +241,17 @@ Sinhala, however, differs considerably in its use of "ZWJ".
  
 ![](sinhala-reph.png)
 
+The zero-width non-joiner (ZWNJ) is not used in shaping runs of
+Sinhala text. The ZWNJ is referenced below in various regular
+expressions and shaping rules, however, because it is used by other
+Indic scripts.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 
 
 

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -496,11 +496,14 @@ _other_		= `OTHER` | `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -570,6 +573,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -1149,20 +1149,32 @@ special forms.
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
 base consonant or syllable base with "half forms" of the consonant
-glyphs. There are four exceptions to the default behavior, for which
-the shaping engine must test:
+glyphs.
+
+In the most common case, this substitution applies to
+"_Consonant_,Halant" sequences that are followed by another
+_Consonant_.
+
+In addition, a sequence matching "_Consonant_,Halant,ZWJ" must also be
+flagged for potential `half` substitutions.
+
+> Note: The presence of the "ZWJ" at the end of the sequence means
+> that the sequence may match the regular-expression test in stage 1
+> as the end of a syllable, even without being followed by a base
+> consonant or syllable base.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+
+There are two exceptions to the default behavior, for which the
+shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been flagged for
     the `rphf` feature earlier, must not be flagged for potential
     `half` substitutions.
-
-  - Non-initial "Ra,Halant" sequences, which should have been flagged
-    for the `rkrf` or `blwf` features earlier, must not be flagged for
-    potential `half` substitutions.
-  
-  - A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" must be
-    flagged for potential `half` substitutions, even though the presence of the
-    zero-width joiner suppresses the `cjct` feature in a later step.
 
   - A sequence matching "_Consonant_,Halant,ZWNJ,_Consonant_" must not be
     flagged for potential `half` substitutions.
@@ -1196,6 +1208,35 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
+
+> Note: The presence of the "ZWJ" in a
+> "_Consonant_,Halant,ZWJ,_Consonant_" sequence should automatically
+> inhibit any `cjct` feature rules from matching the sequence as valid
+> input, and thus prevent the `cjct` substitution from being applied.
+
+> Note: The presence of the "ZWNJ" in a
+> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence means that the
+> "_Consonant_,Halant,ZWNJ" subsequence will match the
+> regular-expression test in stage 1 as the end of a syllable.
+> 
+> Because OpenType shaping features in `<tml2>` are defined as
+> applying only within an individual syllable, this means that the
+> presence of the "ZWNJ" will automatically prevent the application of
+> a `cjct` feature by triggering the identification of a syllable
+> break between the two consonants.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+>
+> Note, also: The presence of the "ZWJ" means that a
+> "_Consonant_,Halant,ZWJ" sequence may match the regular-expression
+> test in stage 1 as the end of a syllable, even without being
+> followed by a base consonant or syllable base. By definition,
+> however, a "_Consonant_,Halant,ZWJ" syllable identified in stage 1
+> cannot also include a "_Consonant_" after the ZWJ.
 
 The font's GSUB rules might be implemented so that `cjct`
 substitutions apply to half-form consonants; therefore, this feature

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -72,7 +72,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -385,7 +385,7 @@ From the shaping engine's perspective, the main distinction between a
 syllable with a base consonant and a syllable with an
 independent-vowel base is that a syllable with an independent-vowel
 base is less likely to include additional consonants in special forms
-and less likely to include depedendent vowel signs
+and less likely to include dependent vowel signs
 (matras). Therefore, in the common case, vowel-based syllables may
 involve less reordering, substitution feature applications, and other
 processing than consonant-based syllables.
@@ -574,7 +574,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -747,7 +747,7 @@ consonants and post-base consonants. Each of these special-form
 consonants must also be tagged (`POS_BELOWBASE_CONSONANT`,
 `POS_POSTBASE_CONSONANT`, respectively). 
 
-Any pre-base-reordering consonant (such as a pre-base-reodering "Ra")
+Any pre-base-reordering consonant (such as a pre-base-reordering "Ra")
 encountered during the base-consonant search must be tagged
 `POS_POSTBASE_CONSONANT`. 
  
@@ -984,7 +984,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 
@@ -1333,7 +1333,7 @@ or ligatures that contain the base consonant or syllable base.
 > Note: The Microsoft script-development specifications for OpenType
 > shaping also state that if a zero-width non-joiner follows the last
 > standalone "Halant", the final matra position is moved to after the
-> non-joiner. However, it is unneccessary to test for this condition,
+> non-joiner. However, it is unnecessary to test for this condition,
 > because a "Halant,ZWNJ" subsequence is, by definition, the end of a
 > syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
 > pre-base dependent vowel.
@@ -1544,7 +1544,7 @@ the `<taml>` script tag and it is known that the font in use supports
 only the `<tml2>` shaping model.
 
 Shaping engines may also choose to apply `blwf` substitutions to
-below-base consonants occuring before the base consonant or syllable base when it is
+below-base consonants occurring before the base consonant or syllable base when it is
 known that the font in use supports an applicable substitution lookup.
 
 Shaping engines may also choose to position left-side matras according

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -252,8 +252,8 @@ text syllables may also use other characters, such as hyphens or dashes,
 in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence.
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence.
 
   - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
     formation of a conjunct between the two consonants. 
@@ -261,7 +261,7 @@ from a "_Consonant_,Halant,_Consonant_" sequence.
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead.
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead.
 
   - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
     the first consonant in its standard form, followed by an explicit
@@ -274,12 +274,12 @@ A secondary usage of the zero-width joiner is to prevent the formation of
     even where an initial "Ra,Halant" sequence without the zero-width
     joiner would otherwise produce a "Reph".
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 
 Tamil text sometimes uses the Latin numerals 2, 3, and 4 in
 superscript or subscript positions to annotate Sanskrit. When used in

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -1149,16 +1149,32 @@ form.
 
 The `half` feature replaces "_Consonant_,Halant" sequences before the
 base consonant or syllable base with "half forms" of the consonant
-glyphs. There are three exceptions to the default behavior, for which
-the shaping engine must test:
+glyphs.
+
+In the most common case, this substitution applies to
+"_Consonant_,Halant" sequences that are followed by another
+_Consonant_.
+
+In addition, a sequence matching "_Consonant_,Halant,ZWJ" must also be
+flagged for potential `half` substitutions.
+
+> Note: The presence of the "ZWJ" at the end of the sequence means
+> that the sequence may match the regular-expression test in stage 1
+> as the end of a syllable, even without being followed by a base
+> consonant or syllable base.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+
+There are two exceptions to the default behavior, for which the
+shaping engine must test:
 
   - Initial "Ra,Halant" sequences, which should have been flagged for
     the `rphf` feature earlier, must not be flagged for potential
     `half` substitutions.
-
-  - A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" must be
-    flagged for potential `half` substitutions, even though the presence of the
-    zero-width joiner suppresses the `cjct` feature in a later step.
 
   - A sequence matching "_Consonant_,Halant,ZWNJ,_Consonant_" must not be
     flagged for potential `half` substitutions.
@@ -1186,6 +1202,35 @@ conjunct ligatures. These sequences must match "_Consonant_,Halant,_Consonant_".
 
 A sequence matching "_Consonant_,Halant,ZWJ,_Consonant_" or
 "_Consonant_,Halant,ZWNJ,_Consonant_" must not be flagged to form a conjunct.
+
+> Note: The presence of the "ZWJ" in a
+> "_Consonant_,Halant,ZWJ,_Consonant_" sequence should automatically
+> inhibit any `cjct` feature rules from matching the sequence as valid
+> input, and thus prevent the `cjct` substitution from being applied.
+
+> Note: The presence of the "ZWNJ" in a
+> "_Consonant_,Halant,ZWNJ,_Consonant_" sequence means that the
+> "_Consonant_,Halant,ZWNJ" subsequence will match the
+> regular-expression test in stage 1 as the end of a syllable.
+> 
+> Because OpenType shaping features in `<tel2>` are defined as
+> applying only within an individual syllable, this means that the
+> presence of the "ZWNJ" will automatically prevent the application of
+> a `cjct` feature by triggering the identification of a syllable
+> break between the two consonants.
+>
+> The fact that the regular-expression tests identify a syllable break
+> after the "_Consonant_,Halant,ZWNJ" is a byproduct of OpenType
+> shaping and Unicode encoding, however, and might not have any
+> significance with regard to the definition of syllables used in the
+> language or orthography of the text.
+>
+> Note, also: The presence of the "ZWJ" means that a
+> "_Consonant_,Halant,ZWJ" sequence may match the regular-expression
+> test in stage 1 as the end of a syllable, even without being
+> followed by a base consonant or syllable base. By definition,
+> however, a "_Consonant_,Halant,ZWJ" syllable identified in stage 1
+> cannot also include a "_Consonant_" after the ZWJ.
 
 The font's GSUB rules might be implemented so that `cjct`
 substitutions apply to half-form consonants; therefore, this feature

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -517,11 +517,14 @@ _other_		= `OTHER` | `MODIFYING_LETTER`
 > Note: The _placeholder_ identification class includes codepoints
 > that are often used in place of vowels or consonants when a document
 > needs to display a matra, mark, or special form in isolation or
-> in another context beyond a standard syllable. Examples include
-> hyphens and non-breaking spaces. The _placeholder_ identification
-> class also includes numerals, which are commonly used as word
-> substitutes within normal text. Examples include ordinals (e.g.,
-> "4th").
+> in another context beyond a standard syllable. Examples of
+> _placeholder_ codepoints include hyphens and non-breaking
+> spaces. Sequences that utilize this approach should be identified as
+> "standalone" syllables.
+>
+> The _placeholder_ identification class also includes numerals, which
+> are commonly used as word substitutes within normal text. Examples
+> include ordinals (e.g., "4th").
 
 > Note: The _other_ identification class includes codepoints that
 > do not interact with adjacent characters for shaping purposes. Even
@@ -591,6 +594,13 @@ A standalone syllable will match the expression:
 > instances in any real-word syllables. Thus, implementations may
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
+
+> Note: Although they are labelled as "standalone syllables" here,
+> many sequences that match the standalone regular expression above
+> are instances where a document needs to display a matra, combining
+> mark, or special form in isolation. Such sequences might not have
+> any significance with regard to the definition of syllables used in
+> the language or orthography of the text.
 
 A symbol-based syllable will match the expression:
 ```markdown

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -77,7 +77,7 @@ consonants. Some of these substitutions create **above-base** or
 **below-base** forms. The **Reph** form of the consonant "Ra" is an
 example.
 
-Syllables may also begin with an **indepedent vowel** instead of a
+Syllables may also begin with an **independent vowel** instead of a
 consonant. In these syllables, the independent vowel is rendered in
 full-letter form, not as a matra, and the independent vowel serves as the
 syllable base, similar to a base consonant.
@@ -391,7 +391,7 @@ From the shaping engine's perspective, the main distinction between a
 syllable with a base consonant and a syllable with an
 independent-vowel base is that a syllable with an independent-vowel
 base is less likely to include additional consonants in special forms
-and less likely to include depedendent vowel signs
+and less likely to include dependent vowel signs
 (matras). Therefore, in the common case, vowel-based syllables may
 involve less reordering, substitution feature applications, and other
 processing than consonant-based syllables.
@@ -595,7 +595,7 @@ A standalone syllable will match the expression:
 > choose to limit occurrences by limiting the above expressions to a
 > finite length, such as `(HALANT_GROUP CN){0,4}` .
 
-> Note: Although they are labelled as "standalone syllables" here,
+> Note: Although they are labeled as "standalone syllables" here,
 > many sequences that match the standalone regular expression above
 > are instances where a document needs to display a matra, combining
 > mark, or special form in isolation. Such sequences might not have
@@ -1012,7 +1012,7 @@ relative position with respect to each other.
 
 #### 2.10: Flag sequences for possible feature applications ####
 
-With the inital reordering complete, those glyphs in the syllable that
+With the initial reordering complete, those glyphs in the syllable that
 may have GSUB or GPOS features applied in stages 3, 5, and 6 should be
 flagged for each potential feature. 
 
@@ -1321,7 +1321,7 @@ the base consonant or syllable base, and all half forms.
 > Note: The Microsoft script-development specifications for OpenType
 > shaping also state that if a zero-width non-joiner follows the last
 > standalone "Halant", the final matra position is moved to after the
-> non-joiner. However, it is unneccessary to test for this condition,
+> non-joiner. However, it is unnecessary to test for this condition,
 > because a "Halant,ZWNJ" subsequence is, by definition, the end of a
 > syllable. Consequently, a "Halant,ZWNJ" cannot be followed by a
 > pre-base dependent vowel.

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -242,8 +242,8 @@ text syllables may also use other characters, such as hyphens or dashes,
 in a similar placeholder fashion; shaping engines should cope with
 this situation gracefully.
 
-The zero-width joiner is primarily used to prevent the formation of a conjunct
-from a "_Consonant_,Halant,_Consonant_" sequence.
+The zero-width joiner (ZWJ) is primarily used to prevent the formation
+of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence.
 
   - The sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the
     formation of a conjunct between the two consonants. 
@@ -251,7 +251,7 @@ from a "_Consonant_,Halant,_Consonant_" sequence.
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner must be used instead.
+conjunct, the zero-width non-joiner (ZWNJ) must be used instead.
 
   - The sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce
     the first consonant in its standard form, followed by an explicit
@@ -269,12 +269,12 @@ other scripts.
   - In Telugu, a "Ra,ZWJ,Halant" sequence will prevent the formation
     of a "Reph" form.
 
-The no-break space is primarily used to display those codepoints that
-are defined as non-spacing (marks, dependent vowels (matras),
-below-base consonant forms, and post-base consonant forms) in an
-isolated context, as an alternative to displaying them superimposed on
-the dotted-circle placeholder. These sequences will match
-"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space (NBSP) is primarily used to display those
+codepoints that are defined as non-spacing (marks, dependent vowels
+(matras), below-base consonant forms, and post-base consonant forms)
+in an isolated context, as an alternative to displaying them
+superimposed on the dotted-circle placeholder. These sequences will
+match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 
 In addition to general punctuation, runs of Telugu text often use the
 danda (`U+0964`) and double danda (`U+0965`) punctuation marks from


### PR DESCRIPTION
Contains sample clarifications regarding NBSP, ZWJ, and ZWNJ, and the term "standalone" syllable, as applied to syllable-identification, `half`, and `cjct`. As per #43. Eventually would be propagated to other Indic2-script docs.