### PR TITLE
Arabic early mark reorder [WIP]

### DIFF
--- a/opentype-shaping-arabic.md
+++ b/opentype-shaping-arabic.md
@@ -14,12 +14,12 @@ implementations share.
 	  - [Mark classification](#mark-classification)
 	  - [Character tables](#character-tables)
   - [The `<arab>` shaping model](#the-arab-shaping-model)
-      - [1. Compound character composition and decomposition](#1-compound-character-composition-and-decomposition)
-      - [2. Computing letter joining states](#2-computing-letter-joining-states)
-      - [3. Applying the `stch` feature](#3-applying-the-stch-feature)
-      - [4. Applying the language-form substitution features from GSUB](#4-applying-the-language-form-substitution-features-from-gsub)
-      - [5. Applying the typographic-form substitution features from GSUB](#5-applying-the-typographic-form-substitution-features-from-gsub)
-      - [6. Mark reordering](#6-mark-reordering)
+      - [1. Transient reordering of modifier combining marks](#1-transient-reordering-of-modifier-combining-marks)
+      - [2. Compound character composition and decomposition](#2-compound-character-composition-and-decomposition)
+      - [3. Computing letter joining states](#3-computing-letter-joining-states)
+      - [4. Applying the `stch` feature](#4-applying-the-stch-feature)
+      - [5. Applying the language-form substitution features from GSUB](#5-applying-the-language-form-substitution-features-from-gsub)
+      - [6. Applying the typographic-form substitution features from GSUB](#6-applying-the-typographic-form-substitution-features-from-gsub)
       - [7. Applying the positioning features from GPOS](#7-applying-the-positioning-features-from-gpos)
   
 
@@ -189,7 +189,8 @@ The sets are:
     (`U+0658`), "Small high seen" (`U+06DC`), "Small high yeh" (`U+06E7`), "Small high
     noon" (`U+06E8`), "Small high waw" (`U+08F3`)
 
-These classifications are used in the [mark-reordering stage](#6-mark-reordering).
+These classifications are used in the [mark-transient-reordering
+stage](#1-transient-reordering-of-modifier-combining-marks).
 
 	
 			
@@ -345,23 +346,74 @@ the dotted-circle placeholder.
 
 Processing a run of `<arab>` text involves seven top-level stages:
 
-1. Compound character composition and decomposition
-2. Computing letter joining states
-3. Applying the `stch` feature
-4. Applying the language-form substitution features from GSUB
-5. Applying the typographic-form substitution features from GSUB
-6. Mark reordering
+1. Transient reordering of modifier combining marks
+2. Compound character composition and decomposition
+3. Computing letter joining states
+4. Applying the `stch` feature
+5. Applying the language-form substitution features from GSUB
+6. Applying the typographic-form substitution features from GSUB
 7. Applying the positioning features from GPOS
 
 
-### 1. Compound character composition and decomposition ###
+### 1. Transient reordering of modifier combining marks ###
+
+<!--- http://www.unicode.org/reports/tr53/tr53-1.pdf --->
+
+Sequences of adjacent marks must be reordered so that they appear in
+the appropriate visual order before the mark-to-base and mark-to-mark
+positioning features from GPOS can be correctly applied.
+
+In particular, those marks that have strong affinity to the base
+character must be placed closest to the base.
+
+This mark-reordering operation is distinct from the standard,
+cross-script mark-reordering performed during Unicode
+normalization. The standard Unicode mark-reordering algorithm is based
+on comparing the _Canonical_Combining_Class_ (Ccc) properties of mark
+codepoints, whereas this script-specific reordering utilizes the
+_Modifier_Combining_Mark_ (`MCM`) subclasses specified in the
+character tables.
+
+The algorithm for reordering a sequence of marks is:
+
+  - First, move any "Shadda" (combining class `33`) characters to the
+    beginning of the mark sequence.
+	
+  -	Second, move any subsequence of combining-class-`230` characters that begins
+       with a `230_MCM` character to the beginning of the sequence,
+       before all "Shadda" characters. The subsequence must be moved
+       as a group.
+
+  - Finally, move any subsequence of combining-class-`220` characters that begins
+       with a `220_MCM` character to the beginning of the sequence,
+       before all "Shadda" characters and before all class-`230`
+       characters. The subsequence must be moved as a group.
+
+> Note: Unicode describes this mark-reordering operation, the Arabic
+> Mark Transient Reordering Algorithm (AMTRA), in Technical Report 53,
+> which describes it in terms that are distinct from standard,
+> Ccc-based mark reordering.
+>
+> Specifically, AMTRA is designated as an operation performed during
+> text rendering only, which therefore does not impact other
+> Unicode-compliance issues such as allowable input sequences or text
+> encoding.
+>
+> However, shaping engines may choose to perform the reordering of
+> modifier combining marks in conjunction with their Unicode
+> normalization functionality for increased efficiency.
+
+### 2. Compound character composition and decomposition ###
 
 The `ccmp` feature allows a font to substitute
 
- - mark-and-base sequences with a pre-composed glyph including both
-   the mark and the base (as is done in with a ligature substitution)
- - individual compound glyphs with the equivalent sequence of
-   decomposed glyphs
+  - mark-and-base sequences with a pre-composed glyph including both
+    the mark and the base (as is done in with a ligature substitution)
+	
+  - individual compound glyphs with the equivalent sequence of
+    decomposed glyphs (such as decomposing a letter with ijam into a
+    separate fundamental-letter glyph followed by an ijam-only glyph,
+    to permit more precise positioning)
  
 If present, these composition and decomposition substitutions must be
 performed before applying any other GSUB or GPOS lookups, because
@@ -369,10 +421,10 @@ those lookups may be written to match only the `ccmp`-substituted
 glyphs. 
 
 
-### 2. Computing letter joining states ###
+### 3. Computing letter joining states ###
 
 In order to correctly apply the initial, medial, and final form
-substitutions from GSUB during stage 5, the shaping engine must
+substitutions from GSUB during stage 6, the shaping engine must
 tag every letter for possible application of the appropriate feature.
 
 > Note: The following algorithm includes rules for processing `<syrc>`
@@ -500,7 +552,7 @@ Updated tag for preceding character:
 At the end of this process, all letters should be tagged for possible
 substitution by one of the `isol`, `init`, `medi`, or `fina` features.
 
-### 3. Applying the `stch` feature ###
+### 4. Applying the `stch` feature ###
 
 The `stch` feature decomposes and stretches special marks that are
 meant to extend to the full width of words to which they are
@@ -536,7 +588,7 @@ Finally, the decomposed mark must be reordered as follows:
     the word.
 	
 
-### 4. Applying the language-form substitution features from GSUB ###
+### 5. Applying the language-form substitution features from GSUB ###
 
 The language-substitution phase applies mandatory substitution
 features using the rules in the font's GSUB table. In preparation for
@@ -559,7 +611,7 @@ all scripts implemented in the Arabic shaping model:
 	calt
 	
 
-#### 4.1 locl ####
+#### 5.1 locl ####
 
 The `locl` feature replaces default glyphs with any language-specific
 variants, based on examining the language setting of the text run.
@@ -574,7 +626,7 @@ variants, based on examining the language setting of the text run.
 ![Localized form substitution](/images/arabic/arabic-locl.png)
 
 
-#### 4.2 isol ####
+#### 5.2 isol ####
 
 The `isol` feature substitutes the default glyph for a codepoint with
 the isolated form of the letter.
@@ -588,7 +640,7 @@ the isolated form of the letter.
 ![Isolated form substitution](/images/arabic/arabic-isol.png)
 
 
-#### 4.3 fina ####
+#### 5.3 fina ####
 
 The `fina` feature substitutes the default glyph for a codepoint with
 the terminal (or final) form of the letter.
@@ -596,15 +648,15 @@ the terminal (or final) form of the letter.
 ![Final form substitution](/images/arabic/arabic-fina.png)
 
 
-#### 4.4 fin2 ####
+#### 5.4 fin2 ####
 
 This feature is not used in `<arab>` text.
 
-#### 4.5 fin3 ####
+#### 5.5 fin3 ####
 
 This feature is not used in `<arab>` text.
 
-#### 4.6 medi ####
+#### 5.6 medi ####
 
 The `medi` feature substitutes the default glyph for a codepoint with
 the medial form of the letter.
@@ -612,11 +664,11 @@ the medial form of the letter.
 ![Medial form substitution](/images/arabic/arabic-medi.png)
 
 
-#### 4.7 med2 ####
+#### 5.7 med2 ####
 
 This feature is not used in `<arab>` text.
 
-#### 4.8 init ####
+#### 5.8 init ####
 
 The `init` feature substitutes the default glyph for a codepoint with
 the initial form of the letter.
@@ -624,7 +676,7 @@ the initial form of the letter.
 ![Initial form substitution](/images/arabic/arabic-init.png)
 
 
-#### 4.9 rlig ####
+#### 5.9 rlig ####
 
 The `rlig` feature substitutes glyph sequences with mandatory
 ligatures. Substitutions made by `rlig` cannot be disabled by
@@ -633,7 +685,7 @@ application-level user interfaces.
 ![Required ligature substitution](/images/arabic/arabic-rlig.png)
 
 
-#### 4.10 rclt ####
+#### 5.10 rclt ####
 
 The `rclt` feature substitutes glyphs with contextual alternate
 forms. In general, this involves replacing the default form of a
@@ -645,7 +697,7 @@ are required by the orthography of the active script and
 language. Substitutions made by `rclt` cannot be disabled by 
 application-level user interfaces.
 
-#### 4.11 calt ####
+#### 5.11 calt ####
 
 The `calt` feature substitutes glyphs with contextual alternate
 forms. In general, this involves replacing the default form of a
@@ -661,7 +713,7 @@ can be disabled by application-level user interfaces.
 
 
 
-### 5. Applying the typographic-form substitution features from GSUB ###
+### 6. Applying the typographic-form substitution features from GSUB ###
 
 The typographic-substitution phase applies optional substitution
 features using the rules in the font's GSUB table.
@@ -675,7 +727,7 @@ all scripts implemented in the Arabic shaping model:
 	mset
 	
 
-#### 5.1 liga ####
+#### 6.1 liga ####
 
 The `liga` feature substitutes standard, optional ligatures that are on
 by default. Substitutions made by `liga` may be disabled by
@@ -685,14 +737,14 @@ application-level user interfaces.
 
 
 
-#### 5.2 dlig ####
+#### 6.2 dlig ####
 
 The `dlig` feature substitutes additional optional ligatures that are
 off by default. Substitutions made by `dlig` may be disabled by
 application-level user interfaces.
 
 
-#### 5.3 cswh ####
+#### 6.3 cswh ####
 
 The `cswh` feature substitutes contextual swash variants of
 glyphs. For example, the active font might substitute a longer variant
@@ -700,7 +752,7 @@ of "Noon" when a certain number of subsequent glyphs do not descend
 below the baseline.
 
 
-#### 5.4 mset ####
+#### 6.4 mset ####
 
 The `mset` feature performs mark positioning by substituting sequences
 of bases and marks with precomposed base-and-mark glyphs.
@@ -713,32 +765,6 @@ of bases and marks with precomposed base-and-mark glyphs.
 > 
 > Nevertheless, when the active font uses `mset` substitutions, the
 > shaping engine must deal with the situation gracefully.
-
-### 6. Mark reordering ###
-
-<!--- http://www.unicode.org/reports/tr53/tr53-1.pdf --->
-
-Sequences of adjacent marks must be reordered so that they appear in
-canonical order before the mark-to-base and mark-to-mark positioning
-features from GPOS can be correctly applied.
-
-In particular, those marks that have strong affinity to the base
-character must be placed closest to the base.
-
-The algorithm for reordering a sequence of marks is:
-
-  - First, move any "Shadda" (combining class `33`) characters to the
-    beginning of the mark sequence.
-	
-  -	Second, move any subsequence of combining-class-`230` characters that begins
-       with a `230_MCM` character to the beginning of the sequence,
-       before all "Shadda" characters. The subsequence must be moved
-       as a group.
-
-  - Finally, move any subsequence of combining-class-`220` characters that begins
-       with a `220_MCM` character to the beginning of the sequence,
-       before all "Shadda" characters and before all class-`230`
-       characters. The subsequence must be moved as a group.
 
 ### 7. Applying the positioning features from GPOS ###
 

--- a/opentype-shaping-arabic.md
+++ b/opentype-shaping-arabic.md
@@ -520,35 +520,6 @@ next word.
 > implement the joining-state computation as a state machine, in a lookup
 > table, or by any other means desirable.
 
-<!--- HarfBuzz state table:
-
-Tag for current character:
-
-| Preceding   | NON_JOINING | LEFT | RIGHT | DUAL or JOIN_CAUSING | syrcAL | syrcDR |
-|:------------|:------------|:-----|:------|:---------------------|:-------|:-------|
-| Current     | | | | | | |
-| NON_JOINING | _none_      |      |       |                      |        |        |
-| LEFT        | `isol`      |      |       |                      |        |        |
-| RIGHT       |             |      |       |                      |        |        |
-| DUAL/CAUS   |             |      |       |                      |        |        |
-| syrcAL      |             |      |       |                      |        |        |
-| syrcDR      |             |      |       |                      |        |        |
-
-
-Updated tag for preceding character:
-
-| Preceding   | NON_JOINING | LEFT | RIGHT | DUAL or JOIN_CAUSING | syrcAL | syrcDR |
-|:------------|:------------|:-----|:------|:---------------------|:-------|:-------|
-| Current     | | | | | | |
-| NON_JOINING |             |      |       |                      |        |        |
-| LEFT        |             |      |       |                      |        |        |
-| RIGHT       |             |      |       |                      |        |        |
-| DUAL/CAUS   |             |      |       |                      |        |        |
-| syrcAL      |             |      |       |                      |        |        |
-| syrcDR      |             |      |       |                      |        |        |
-
---->
-
 At the end of this process, all letters should be tagged for possible
 substitution by one of the `isol`, `init`, `medi`, or `fina` features.
 

--- a/opentype-shaping-mongolian.md
+++ b/opentype-shaping-mongolian.md
@@ -14,12 +14,12 @@ implementations share.
 	  - [Mark classification](#mark-classification)
 	  - [Character tables](#character-tables)
   - [The `<mong>` shaping model](#the-arab-shaping-model)
-      - [1. Compound character composition and decomposition](#1-compound-character-composition-and-decomposition)
-      - [2. Computing letter joining states](#2-computing-letter-joining-states)
-      - [3. Applying the `stch` feature](#3-applying-the-stch-feature)
-      - [4. Applying the language-form substitution features from GSUB](#4-applying-the-language-form-substitution-features-from-gsub)
-      - [5. Applying the typographic-form substitution features from GSUB](#5-applying-the-typographic-form-substitution-features-from-gsub)
-      - [6. Mark reordering](#6-mark-reordering)
+      - [1. Transient reordering of modifier combining marks](#1-transient-reordering-of-modifier-combining-marks)
+      - [2. Compound character composition and decomposition](#2-compound-character-composition-and-decomposition)
+      - [3. Computing letter joining states](#3-computing-letter-joining-states)
+      - [4. Applying the `stch` feature](#4-applying-the-stch-feature)
+      - [5. Applying the language-form substitution features from GSUB](#5-applying-the-language-form-substitution-features-from-gsub)
+      - [6. Applying the typographic-form substitution features from GSUB](#6-applying-the-typographic-form-substitution-features-from-gsub)
       - [7. Applying the positioning features from GPOS](#7-applying-the-positioning-features-from-gpos)
   
 
@@ -323,23 +323,79 @@ suffix. Not all Mongolian words incorporate a narrow no-break space.
 
 Processing a run of `<mong>` text involves seven top-level stages:
 
-1. Compound character composition and decomposition
-2. Computing letter joining states
-3. Applying the `stch` feature
-4. Applying the language-form substitution features from GSUB
-5. Applying the typographic-form substitution features from GSUB
-6. Mark reordering
+1. Transient reordering of modifier combining marks
+2. Compound character composition and decomposition
+3. Computing letter joining states
+4. Applying the `stch` feature
+5. Applying the language-form substitution features from GSUB
+6. Applying the typographic-form substitution features from GSUB
 7. Applying the positioning features from GPOS
 
 
-### 1. Compound character composition and decomposition ###
+### 1. Transient reordering of modifier combining marks ###
+
+<!--- http://www.unicode.org/reports/tr53/tr53-1.pdf --->
+> Note: because Mongolian does not feature the "Shadda" mark or any
+> marks that belong to _Modifier Combining Marks_ (MCM) classes, this
+> stage should not involve any additional work when processing
+> `<mong>` text runs. It is included here to maintain consistency with
+> other scripts that utilize the general Arabic-based shaping model.
+
+Sequences of adjacent marks must be reordered so that they appear in
+the appropriate visual order before the mark-to-base and mark-to-mark
+positioning features from GPOS can be correctly applied.
+
+In particular, those marks that have strong affinity to the base
+character must be placed closest to the base.
+
+This mark-reordering operation is distinct from the standard,
+cross-script mark-reordering performed during Unicode
+normalization. The standard Unicode mark-reordering algorithm is based
+on comparing the _Canonical_Combining_Class_ (Ccc) properties of mark
+codepoints, whereas this script-specific reordering utilizes the
+_Modifier_Combining_Mark_ (`MCM`) subclasses specified in the
+character tables.
+
+The algorithm for reordering a sequence of marks is:
+
+  - First, move any "Shadda" (combining class `33`) characters to the
+    beginning of the mark sequence.
+	
+  -	Second, move any subsequence of combining-class-`230` characters that begins
+       with a `230_MCM` character to the beginning of the sequence,
+       before all "Shadda" characters. The subsequence must be moved
+       as a group.
+
+  - Finally, move any subsequence of combining-class-`220` characters that begins
+       with a `220_MCM` character to the beginning of the sequence,
+       before all "Shadda" characters and before all class-`230`
+       characters. The subsequence must be moved as a group.
+
+> Note: Unicode describes this mark-reordering operation, the Arabic
+> Mark Transient Reordering Algorithm (AMTRA), in Technical Report 53,
+> which describes it in terms that are distinct from standard,
+> Ccc-based mark reordering.
+>
+> Specifically, AMTRA is designated as an operation performed during
+> text rendering only, which therefore does not impact other
+> Unicode-compliance issues such as allowable input sequences or text
+> encoding.
+>
+> However, shaping engines may choose to perform the reordering of
+> modifier combining marks in conjunction with their Unicode
+> normalization functionality for increased efficiency.
+
+### 2. Compound character composition and decomposition ###
 
 The `ccmp` feature allows a font to substitute
 
  - mark-and-base sequences with a pre-composed glyph including both
-   the mark and the base (as is done in with a ligature substitution)
- - individual compound glyphs with the equivalent sequence of
-   decomposed glyphs
+    the mark and the base (as is done in with a ligature substitution)
+	
+  - individual compound glyphs with the equivalent sequence of
+    decomposed glyphs (such as decomposing a letter with inherent
+    marks into a separate fundamental-letter glyph followed by a
+    marks-only glyph, to permit more precise positioning)
  
 If present, these composition and decomposition substitutions must be
 performed before applying any other GSUB or GPOS lookups, because
@@ -347,10 +403,10 @@ those lookups may be written to match only the `ccmp`-substituted
 glyphs. 
 
 
-### 2. Computing letter joining states ###
+### 3. Computing letter joining states ###
 
 In order to correctly apply the initial, medial, and final form
-substitutions from GSUB during stage 5, the shaping engine must
+substitutions from GSUB during stage 6, the shaping engine must
 tag every letter for possible application of the appropriate feature.
 
 > Note: The following algorithm includes rules for processing `<syrc>`
@@ -449,7 +505,7 @@ next word.
 At the end of this process, all letters should be tagged for possible
 substitution by one of the `isol`, `init`, `medi`, or `fina` features.
 
-### 3. Applying the `stch` feature ###
+### 4. Applying the `stch` feature ###
 
 The `stch` feature decomposes and stretches special marks that are
 meant to extend to the full width of words to which they are
@@ -485,7 +541,7 @@ Finally, the decomposed mark must be reordered as follows:
     the word.
 	
 
-### 4. Applying the language-form substitution features from GSUB ###
+### 5. Applying the language-form substitution features from GSUB ###
 
 The language-substitution phase applies mandatory substitution
 features using the rules in the font's GSUB table. In preparation for
@@ -508,7 +564,7 @@ all scripts implemented in the Arabic shaping model:
 	calt
 	
 
-#### 4.1 locl ####
+#### 5.1 locl ####
 
 The `locl` feature replaces default glyphs with any language-specific
 variants, based on examining the language setting of the text run.
@@ -521,7 +577,7 @@ variants, based on examining the language setting of the text run.
 > GSUB substitutions in the following steps.
 
 
-#### 4.2 isol ####
+#### 5.2 isol ####
 
 The `isol` feature substitutes the default glyph for a codepoint with
 the isolated form of the letter.
@@ -542,7 +598,7 @@ by the orthography.
 ![Isolated FVS1 form substitution](/images/mongolian/mongolian-isol-fvs1.png)
 
 
-#### 4.3 fina ####
+#### 5.3 fina ####
 
 The `fina` feature substitutes the default glyph for a codepoint with
 the terminal (or final) form of the letter.
@@ -557,15 +613,15 @@ by the orthography.
 ![Final FVS2 form substitution](/images/mongolian/mongolian-fina-fvs2.png)
 
 
-#### 4.4 fin2 ####
+#### 5.4 fin2 ####
 
 This feature is not used in `<mong>` text.
 
-#### 4.5 fin3 ####
+#### 5.5 fin3 ####
 
 This feature is not used in `<mong>` text.
 
-#### 4.6 medi ####
+#### 5.6 medi ####
 
 The `medi` feature substitutes the default glyph for a codepoint with
 the medial form of the letter.
@@ -580,11 +636,11 @@ by the orthography.
 ![Medial FVS1 form substitution](/images/mongolian/mongolian-medi-fvs1.png)
 
 
-#### 4.7 med2 ####
+#### 5.7 med2 ####
 
 This feature is not used in `<mong>` text.
 
-#### 4.8 init ####
+#### 5.8 init ####
 
 The `init` feature substitutes the default glyph for a codepoint with
 the initial form of the letter.
@@ -599,7 +655,7 @@ by the orthography.
 ![Initial FVS1 form substitution](/images/mongolian/mongolian-init-fvs1.png)
 
 
-#### 4.9 rlig ####
+#### 5.9 rlig ####
 
 The `rlig` feature substitutes glyph sequences with mandatory
 ligatures. Substitutions made by `rlig` cannot be disabled by
@@ -608,7 +664,7 @@ application-level user interfaces.
 ![Required ligature substitution](/images/mongolian/mongolian-rlig.png)
 
 
-#### 4.10 rclt ####
+#### 5.10 rclt ####
 
 The `rclt` feature substitutes glyphs with contextual alternate
 forms. In general, this involves replacing the default form of a
@@ -620,7 +676,7 @@ are required by the orthography of the active script and
 language. Substitutions made by `rclt` cannot be disabled by 
 application-level user interfaces.
 
-#### 4.11 calt ####
+#### 5.11 calt ####
 
 The `calt` feature substitutes glyphs with contextual alternate
 forms. In general, this involves replacing the default form of a
@@ -636,7 +692,7 @@ can be disabled by application-level user interfaces.
 
 
 
-### 5. Applying the typographic-form substitution features from GSUB ###
+### 6. Applying the typographic-form substitution features from GSUB ###
 
 The typographic-substitution phase applies optional substitution
 features using the rules in the font's GSUB table.
@@ -650,7 +706,7 @@ all scripts implemented in the Arabic shaping model:
 	mset
 	
 
-#### 5.1 liga ####
+#### 6.1 liga ####
 
 The `liga` feature substitutes standard, optional ligatures that are on
 by default. Substitutions made by `liga` may be disabled by
@@ -660,14 +716,14 @@ application-level user interfaces.
 
 
 
-#### 5.2 dlig ####
+#### 6.2 dlig ####
 
 The `dlig` feature substitutes additional optional ligatures that are
 off by default. Substitutions made by `dlig` may be disabled by
 application-level user interfaces.
 
 
-#### 5.3 cswh ####
+#### 6.3 cswh ####
 
 The `cswh` feature substitutes contextual swash variants of
 glyphs. 
@@ -677,7 +733,7 @@ of "Noon" when a certain number of subsequent glyphs do not descend
 below the baseline. --->
 
 
-#### 5.4 mset ####
+#### 6.4 mset ####
 
 The `mset` feature performs mark positioning by substituting sequences
 of bases and marks with precomposed base-and-mark glyphs.
@@ -690,39 +746,6 @@ of bases and marks with precomposed base-and-mark glyphs.
 > 
 > Nevertheless, when the active font uses `mset` substitutions, the
 > shaping engine must deal with the situation gracefully.
-
-### 6. Mark reordering ###
-
-<!--- http://www.unicode.org/reports/tr53/tr53-1.pdf --->
-
-Sequences of adjacent marks must be reordered so that they appear in
-canonical order before the mark-to-base and mark-to-mark positioning
-features from GPOS can be correctly applied.
-
-> Note: because Mongolian does not feature the "Shadda" mark or any
-> marks that belong to _Modifier Combining Marks_ (MCM) classes, this
-> stage should not involve any additional work when processing
-> `<mong>` text runs. It is included here to maintain consistency with
-> other scripts that utilize the general Arabic-based shaping model.
-
-In particular, those marks that have strong affinity to the base
-character must be placed closest to the base.
-
-The algorithm for reordering a sequence of marks is:
-
-  - First, move any "Shadda" (combining class `33`) characters to the
-    beginning of the mark sequence.
-	
-  -	Second, move any subsequence of combining-class-`230` characters that begins
-       with a `230_MCM` character to the beginning of the sequence,
-       before all "Shadda" characters. The subsequence must be moved
-       as a group.
-
-  - Finally, move any subsequence of combining-class-`220` characters that begins
-       with a `220_MCM` character to the beginning of the sequence,
-       before all "Shadda" characters and before all class-`230`
-       characters. The subsequence must be moved as a group.
-
 
 ### 7. Applying the positioning features from GPOS ###
 

--- a/opentype-shaping-nko.md
+++ b/opentype-shaping-nko.md
@@ -14,12 +14,12 @@ implementations share.
 	  - [Mark classification](#mark-classification)
 	  - [Character tables](#character-tables)
   - [The `<nko >` shaping model](#the-arab-shaping-model)
-      - [1. Compound character composition and decomposition](#1-compound-character-composition-and-decomposition)
-      - [2. Computing letter joining states](#2-computing-letter-joining-states)
-      - [3. Applying the `stch` feature](#3-applying-the-stch-feature)
-      - [4. Applying the language-form substitution features from GSUB](#4-applying-the-language-form-substitution-features-from-gsub)
-      - [5. Applying the typographic-form substitution features from GSUB](#5-applying-the-typographic-form-substitution-features-from-gsub)
-      - [6. Mark reordering](#6-mark-reordering)
+      - [1. Transient reordering of modifier combining marks](#1-transient-reordering-of-modifier-combining-marks)
+      - [2. Compound character composition and decomposition](#2-compound-character-composition-and-decomposition)
+      - [3. Computing letter joining states](#3-computing-letter-joining-states)
+      - [4. Applying the `stch` feature](#4-applying-the-stch-feature)
+      - [5. Applying the language-form substitution features from GSUB](#5-applying-the-language-form-substitution-features-from-gsub)
+      - [6. Applying the typographic-form substitution features from GSUB](#6-applying-the-typographic-form-substitution-features-from-gsub)
       - [7. Applying the positioning features from GPOS](#7-applying-the-positioning-features-from-gpos)
   
 
@@ -137,7 +137,8 @@ The numeric values of these combining classes are used during Unicode
 normalization.
 
 
-
+These classifications are used in the [mark-transient-reordering
+stage](#1-transient-reordering-of-modifier-combining-marks).
 
 			
 			
@@ -274,23 +275,79 @@ the dotted-circle placeholder.
 
 Processing a run of `<nko >` text involves seven top-level stages:
 
-1. Compound character composition and decomposition
-2. Computing letter joining states
-3. Applying the `stch` feature
-4. Applying the language-form substitution features from GSUB
-5. Applying the typographic-form substitution features from GSUB
-6. Mark reordering
+1. Transient reordering of modifier combining marks
+2. Compound character composition and decomposition
+3. Computing letter joining states
+4. Applying the `stch` feature
+5. Applying the language-form substitution features from GSUB
+6. Applying the typographic-form substitution features from GSUB
 7. Applying the positioning features from GPOS
 
+
+### 1. Transient reordering of modifier combining marks ###
+
+<!--- http://www.unicode.org/reports/tr53/tr53-1.pdf --->
+> Note: because N'Ko does not feature the "Shadda" mark or any
+> marks that belong to _Modifier Combining Marks_ (MCM) classes, this
+> stage should not involve any additional work when processing
+> `<nko >` text runs. It is included here to maintain consistency with
+> other scripts that utilize the general Arabic-based shaping model.
+
+Sequences of adjacent marks must be reordered so that they appear in
+the appropriate visual order before the mark-to-base and mark-to-mark
+positioning features from GPOS can be correctly applied.
+
+In particular, those marks that have strong affinity to the base
+character must be placed closest to the base.
+
+This mark-reordering operation is distinct from the standard,
+cross-script mark-reordering performed during Unicode
+normalization. The standard Unicode mark-reordering algorithm is based
+on comparing the _Canonical_Combining_Class_ (Ccc) properties of mark
+codepoints, whereas this script-specific reordering utilizes the
+_Modifier_Combining_Mark_ (`MCM`) subclasses specified in the
+character tables.
+
+The algorithm for reordering a sequence of marks is:
+
+  - First, move any "Shadda" (combining class `33`) characters to the
+    beginning of the mark sequence.
+	
+  -	Second, move any subsequence of combining-class-`230` characters that begins
+       with a `230_MCM` character to the beginning of the sequence,
+       before all "Shadda" characters. The subsequence must be moved
+       as a group.
+
+  - Finally, move any subsequence of combining-class-`220` characters that begins
+       with a `220_MCM` character to the beginning of the sequence,
+       before all "Shadda" characters and before all class-`230`
+       characters. The subsequence must be moved as a group.
+
+> Note: Unicode describes this mark-reordering operation, the Arabic
+> Mark Transient Reordering Algorithm (AMTRA), in Technical Report 53,
+> which describes it in terms that are distinct from standard,
+> Ccc-based mark reordering.
+>
+> Specifically, AMTRA is designated as an operation performed during
+> text rendering only, which therefore does not impact other
+> Unicode-compliance issues such as allowable input sequences or text
+> encoding.
+>
+> However, shaping engines may choose to perform the reordering of
+> modifier combining marks in conjunction with their Unicode
+> normalization functionality for increased efficiency.
 
 ### 1. Compound character composition and decomposition ###
 
 The `ccmp` feature allows a font to substitute
 
  - mark-and-base sequences with a pre-composed glyph including both
-   the mark and the base (as is done in with a ligature substitution)
- - individual compound glyphs with the equivalent sequence of
-   decomposed glyphs
+    the mark and the base (as is done in with a ligature substitution)
+	
+  - individual compound glyphs with the equivalent sequence of
+    decomposed glyphs (such as decomposing a letter with inherent
+    marks into a separate fundamental-letter glyph followed by an
+    marks-only glyph, to permit more precise positioning) 
  
 If present, these composition and decomposition substitutions must be
 performed before applying any other GSUB or GPOS lookups, because
@@ -298,10 +355,10 @@ those lookups may be written to match only the `ccmp`-substituted
 glyphs. 
 
 
-### 2. Computing letter joining states ###
+### 3. Computing letter joining states ###
 
 In order to correctly apply the initial, medial, and final form
-substitutions from GSUB during stage 5, the shaping engine must
+substitutions from GSUB during stage 6, the shaping engine must
 tag every letter for possible application of the appropriate feature.
 
 > Note: The following algorithm includes rules for processing `<syrc>`
@@ -401,7 +458,7 @@ next word.
 At the end of this process, all letters should be tagged for possible
 substitution by one of the `isol`, `init`, `medi`, or `fina` features.
 
-### 3. Applying the `stch` feature ###
+### 4. Applying the `stch` feature ###
 
 The `stch` feature decomposes and stretches special marks that are
 meant to extend to the full width of words to which they are
@@ -441,7 +498,7 @@ Finally, the decomposed mark must be reordered as follows:
     the word.
 	
 
-### 4. Applying the language-form substitution features from GSUB ###
+### 5. Applying the language-form substitution features from GSUB ###
 
 The language-substitution phase applies mandatory substitution
 features using the rules in the font's GSUB table. In preparation for
@@ -464,7 +521,7 @@ all scripts implemented in the N'Ko shaping model:
 	calt
 	
 
-#### 4.1 locl ####
+#### 5.1 locl ####
 
 The `locl` feature replaces default glyphs with any language-specific
 variants, based on examining the language setting of the text run.
@@ -479,7 +536,7 @@ variants, based on examining the language setting of the text run.
 <!--- ![Localized form substitution](/images/nko/nko-locl.png) --->
 
 
-#### 4.2 isol ####
+#### 5.2 isol ####
 
 The `isol` feature substitutes the default glyph for a codepoint with
 the isolated form of the letter.
@@ -493,7 +550,7 @@ the isolated form of the letter.
 <!--- ![Isolated form substitution](/images/nko/nko-isol.png) --->
 
 
-#### 4.3 fina ####
+#### 5.3 fina ####
 
 The `fina` feature substitutes the default glyph for a codepoint with
 the terminal (or final) form of the letter.
@@ -501,15 +558,15 @@ the terminal (or final) form of the letter.
 ![Final form substitution](/images/nko/nko-fina.png)
 
 
-#### 4.4 fin2 ####
+#### 5.4 fin2 ####
 
 This feature is not used in `<nko >` text.
 
-#### 4.5 fin3 ####
+#### 5.5 fin3 ####
 
 This feature is not used in `<nko >` text.
 
-#### 4.6 medi ####
+#### 5.6 medi ####
 
 The `medi` feature substitutes the default glyph for a codepoint with
 the medial form of the letter.
@@ -517,11 +574,11 @@ the medial form of the letter.
 ![Medial form substitution](/images/nko/nko-medi.png)
 
 
-#### 4.7 med2 ####
+#### 5.7 med2 ####
 
 This feature is not used in `<nko >` text.
 
-#### 4.8 init ####
+#### 5.8 init ####
 
 The `init` feature substitutes the default glyph for a codepoint with
 the initial form of the letter.
@@ -529,19 +586,19 @@ the initial form of the letter.
 ![Initial form substitution](/images/nko/nko-init.png)
 
 
-#### 4.9 rlig ####
+#### 5.9 rlig ####
 
 This feature is not used in `<nko >` text.
 
 
 
-#### 4.10 rclt ####
+#### 5.10 rclt ####
 
 This feature is not used in `<nko >` text.
 
 
 
-#### 4.11 calt ####
+#### 5.11 calt ####
 
 The `calt` feature substitutes glyphs with contextual alternate
 forms. In general, this involves replacing the default form of a
@@ -557,7 +614,7 @@ can be disabled by application-level user interfaces.
 
 
 
-### 5. Applying the typographic-form substitution features from GSUB ###
+### 6. Applying the typographic-form substitution features from GSUB ###
 
 The typographic-substitution phase applies optional substitution
 features using the rules in the font's GSUB table.
@@ -571,7 +628,7 @@ all scripts implemented in the N'Ko shaping model:
 	mset (not used in N'Ko)
 	
 
-#### 5.1 liga ####
+#### 6.1 liga ####
 
 The `liga` feature substitutes standard, optional ligatures that are on
 by default. Substitutions made by `liga` may be disabled by
@@ -581,55 +638,23 @@ application-level user interfaces.
 
 
 
-#### 5.2 dlig ####
+#### 6.2 dlig ####
 
 The `dlig` feature substitutes additional optional ligatures that are
 off by default. Substitutions made by `dlig` may be disabled by
 application-level user interfaces.
 
 
-#### 5.3 cswh ####
+#### 6.3 cswh ####
 
 This feature is not used in `<nko >` text.
 
 
 
-#### 5.4 mset ####
+#### 6.4 mset ####
 
 This feature is not used in `<nko >` text.
 
-
-### 6. Mark reordering ###
-
-<!--- http://www.unicode.org/reports/tr53/tr53-1.pdf --->
-
-Sequences of adjacent marks must be reordered so that they appear in
-canonical order before the mark-to-base and mark-to-mark positioning
-features from GPOS can be correctly applied.
-
-In particular, those marks that have strong affinity to the base
-character must be placed closest to the base.
-
-> Note: because N'Ko does not feature the "Shadda" mark or any
-> marks that belong to _Modifier Combining Marks_ (MCM) classes, this
-> stage should not involve any additional work when processing
-> `<nko >` text runs. It is included here to maintain consistency with
-> other scripts that utilize the general Arabic-based shaping model.
-
-The algorithm for reordering a sequence of marks is:
-
-  - First, move any "Shadda" (combining class `33`) characters to the
-    beginning of the mark sequence.
-	
-  -	Second, move any subsequence of combining-class-`230` characters that begins
-       with a `230_MCM` character to the beginning of the sequence,
-       before all "Shadda" characters. The subsequence must be moved
-       as a group.
-
-  - Finally, move any subsequence of combining-class-`220` characters that begins
-       with a `220_MCM` character to the beginning of the sequence,
-       before all "Shadda" characters and before all class-`230`
-       characters. The subsequence must be moved as a group.
 
 ### 7. Applying the positioning features from GPOS ###
 

--- a/opentype-shaping-normalization.md
+++ b/opentype-shaping-normalization.md
@@ -333,8 +333,8 @@ order:
 Several script-specific shapers require additional reordering to
 compensate for limitations in the Unicode `Ccc` mark-reordering
 model. For example, several Arabic mark sequences are reordered in
-[stage 6](/opentype-shaping-arabic.md#6-mark-reordering) of the Arabic
-shaping model and [stage 6](/opentype-shaping-syriac.md#6-mark-reordering)
+[stage 1](/opentype-shaping-arabic.md#1-transient-reordering-of-modifier-combining-marks) of the Arabic
+shaping model and [stage 1](/opentype-shaping-syriac.md#1-transient-reordering-of-modifier-combining-marks)
 of the Syriac shaping model. 
 
 These are listed briefly in stage 4, step 4, below, but full
@@ -542,8 +542,8 @@ example:
   - In the Hebrew shaper, stage 2, Hebrew Alphabetic Presentation
     Forms, if available in the active font, are composed.
 
-  - In the Arabic shaping model, stage 6, and in the Syriac shaping
-    model, stage 6, certain marks are reordered after normalization
+  - In the Arabic shaping model, stage 1, and in the Syriac shaping
+    model, stage 1, certain marks are reordered after normalization
     and after GSUB feature application.
 
   - In Bengali, "Ya, Nukta" is composed into "Yya" before GSUB feature

--- a/opentype-shaping-syriac.md
+++ b/opentype-shaping-syriac.md
@@ -356,6 +356,11 @@ Processing a run of `<syrc>` text involves seven top-level stages:
 
 <!--- http://www.unicode.org/reports/tr53/tr53-1.pdf --->
 
+> Note: The following algorithm contains steps specific to reordering
+> Arabic marks. Since Garshuni text, which uses the Syriac script to
+> write the Arabic language, employs Arabic marks, shaping engines
+> should not omit the mark-reordering logic. 
+
 Sequences of adjacent marks must be reordered so that they appear in
 the appropriate visual order before the mark-to-base and mark-to-mark
 positioning features from GPOS can be correctly applied.

--- a/opentype-shaping-syriac.md
+++ b/opentype-shaping-syriac.md
@@ -14,12 +14,12 @@ implementations share.
 	  - [Mark classification](#mark-classification)
 	  - [Character tables](#character-tables)
   - [The `<syrc>` shaping model](#the-arab-shaping-model)
-      - [1. Compound character composition and decomposition](#1-compound-character-composition-and-decomposition)
-      - [2. Computing letter joining states](#2-computing-letter-joining-states)
-      - [3. Applying the `stch` feature](#3-applying-the-stch-feature)
-      - [4. Applying the language-form substitution features from GSUB](#4-applying-the-language-form-substitution-features-from-gsub)
-      - [5. Applying the typographic-form substitution features from GSUB](#5-applying-the-typographic-form-substitution-features-from-gsub)
-      - [6. Mark reordering](#6-mark-reordering)
+      - [1. Transient reordering of modifier combining marks](#1-transient-reordering-of-modifier-combining-marks)
+      - [2. Compound character composition and decomposition](#2-compound-character-composition-and-decomposition)
+      - [3. Computing letter joining states](#3-computing-letter-joining-states)
+      - [4. Applying the `stch` feature](#4-applying-the-stch-feature)
+      - [5. Applying the language-form substitution features from GSUB](#5-applying-the-language-form-substitution-features-from-gsub)
+      - [6. Applying the typographic-form substitution features from GSUB](#6-applying-the-typographic-form-substitution-features-from-gsub)
       - [7. Applying the positioning features from GPOS](#7-applying-the-positioning-features-from-gpos)
   
 
@@ -195,7 +195,8 @@ The numeric values of these combining classes are used during Unicode
 normalization.
 
 
-These classifications are used in the [mark-reordering stage](#6-mark-reordering).
+These classifications are used in the [mark-transient-reordering
+stage](#1-transient-reordering-of-modifier-combining-marks).
 
 			
 ### Character tables ###
@@ -342,23 +343,74 @@ the dotted-circle placeholder.
 
 Processing a run of `<syrc>` text involves seven top-level stages:
 
-1. Compound character composition and decomposition
-2. Computing letter joining states
-3. Applying the `stch` feature
-4. Applying the language-form substitution features from GSUB
-5. Applying the typographic-form substitution features from GSUB
-6. Mark reordering
+1. Transient reordering of modifier combining marks
+2. Compound character composition and decomposition
+3. Computing letter joining states
+4. Applying the `stch` feature
+5. Applying the language-form substitution features from GSUB
+6. Applying the typographic-form substitution features from GSUB
 7. Applying the positioning features from GPOS
 
 
-### 1. Compound character composition and decomposition ###
+### 1. Transient reordering of modifier combining marks ###
+
+<!--- http://www.unicode.org/reports/tr53/tr53-1.pdf --->
+
+Sequences of adjacent marks must be reordered so that they appear in
+the appropriate visual order before the mark-to-base and mark-to-mark
+positioning features from GPOS can be correctly applied.
+
+In particular, those marks that have strong affinity to the base
+character must be placed closest to the base.
+
+This mark-reordering operation is distinct from the standard,
+cross-script mark-reordering performed during Unicode
+normalization. The standard Unicode mark-reordering algorithm is based
+on comparing the _Canonical_Combining_Class_ (Ccc) properties of mark
+codepoints, whereas this script-specific reordering utilizes the
+_Modifier_Combining_Mark_ (`MCM`) subclasses specified in the
+character tables.
+
+The algorithm for reordering a sequence of marks is:
+
+  - First, move any "Shadda" (combining class `33`) characters to the
+    beginning of the mark sequence.
+	
+  -	Second, move any subsequence of combining-class-`230` characters that begins
+       with a `230_MCM` character to the beginning of the sequence,
+       before all "Shadda" characters. The subsequence must be moved
+       as a group.
+
+  - Finally, move any subsequence of combining-class-`220` characters that begins
+       with a `220_MCM` character to the beginning of the sequence,
+       before all "Shadda" characters and before all class-`230`
+       characters. The subsequence must be moved as a group.
+
+> Note: Unicode describes this mark-reordering operation, the Arabic
+> Mark Transient Reordering Algorithm (AMTRA), in Technical Report 53,
+> which describes it in terms that are distinct from standard,
+> Ccc-based mark reordering.
+>
+> Specifically, AMTRA is designated as an operation performed during
+> text rendering only, which therefore does not impact other
+> Unicode-compliance issues such as allowable input sequences or text
+> encoding.
+>
+> However, shaping engines may choose to perform the reordering of
+> modifier combining marks in conjunction with their Unicode
+> normalization functionality for increased efficiency.
+
+### 2. Compound character composition and decomposition ###
 
 The `ccmp` feature allows a font to substitute
 
  - mark-and-base sequences with a pre-composed glyph including both
-   the mark and the base (as is done in with a ligature substitution)
- - individual compound glyphs with the equivalent sequence of
-   decomposed glyphs
+    the mark and the base (as is done in with a ligature substitution)
+	
+  - individual compound glyphs with the equivalent sequence of
+    decomposed glyphs (such as decomposing a letter with Majlīyānā or
+    other marks into a separate fundamental-letter glyph followed by a
+    mark-only glyph, to permit more precise positioning)
  
 If present, these composition and decomposition substitutions must be
 performed before applying any other GSUB or GPOS lookups, because
@@ -366,10 +418,10 @@ those lookups may be written to match only the `ccmp`-substituted
 glyphs. 
 
 
-### 2. Computing letter joining states ###
+### 3. Computing letter joining states ###
 
 In order to correctly apply the initial, medial, and final form
-substitutions from GSUB during stage 5, the shaping engine must
+substitutions from GSUB during stage 6, the shaping engine must
 tag every letter for possible application of the appropriate feature.
 
 To determine which feature is appropriate, the shaping engine must
@@ -460,39 +512,10 @@ next word.
 > implement the joining-state computation as a state machine, in a lookup
 > table, or by any other means desirable.
 
-<!--- HarfBuzz state table:
-
-Tag for current character:
-
-| Preceding   | NON_JOINING | LEFT | RIGHT | DUAL or JOIN_CAUSING | syrcAL | syrcDR |
-|:------------|:------------|:-----|:------|:---------------------|:-------|:-------|
-| Current     | | | | | | |
-| NON_JOINING | _none_      |      |       |                      |        |        |
-| LEFT        | `isol`      |      |       |                      |        |        |
-| RIGHT       |             |      |       |                      |        |        |
-| DUAL/CAUS   |             |      |       |                      |        |        |
-| syrcAL      |             |      |       |                      |        |        |
-| syrcDR      |             |      |       |                      |        |        |
-
-
-Updated tag for preceding character:
-
-| Preceding   | NON_JOINING | LEFT | RIGHT | DUAL or JOIN_CAUSING | syrcAL | syrcDR |
-|:------------|:------------|:-----|:------|:---------------------|:-------|:-------|
-| Current     | | | | | | |
-| NON_JOINING |             |      |       |                      |        |        |
-| LEFT        |             |      |       |                      |        |        |
-| RIGHT       |             |      |       |                      |        |        |
-| DUAL/CAUS   |             |      |       |                      |        |        |
-| syrcAL      |             |      |       |                      |        |        |
-| syrcDR      |             |      |       |                      |        |        |
-
---->
-
 At the end of this process, all letters should be tagged for possible
 substitution by one of the `isol`, `init`, `medi`, or `fina` features.
 
-### 3. Applying the `stch` feature ###
+### 4. Applying the `stch` feature ###
 
 The `stch` feature decomposes and stretches special marks that are
 meant to extend to the full width of words to which they are
@@ -528,7 +551,7 @@ Finally, the decomposed mark must be reordered as follows:
     the word.
 	
 
-### 4. Applying the language-form substitution features from GSUB ###
+### 5. Applying the language-form substitution features from GSUB ###
 
 The language-substitution phase applies mandatory substitution
 features using the rules in the font's GSUB table. In preparation for
@@ -551,7 +574,7 @@ all scripts implemented in the Arabic shaping model:
 	calt
 	
 
-#### 4.1 locl ####
+#### 5.1 locl ####
 
 The `locl` feature replaces default glyphs with any language-specific
 variants, based on examining the language setting of the text run.
@@ -566,7 +589,7 @@ variants, based on examining the language setting of the text run.
 <!--- ![Localized form substitution](/images/syriac/syriac-locl.png) --->
 
 
-#### 4.2 isol ####
+#### 5.2 isol ####
 
 The `isol` feature substitutes the default glyph for a codepoint with
 the isolated form of the letter.
@@ -580,7 +603,7 @@ the isolated form of the letter.
 <!--- ![Isolated form substitution](/images/syriac/syriac-isol.png) --->
 
 
-#### 4.3 fina ####
+#### 5.3 fina ####
 
 The `fina` feature substitutes the default glyph for a codepoint with
 the terminal (or final) form of the letter.
@@ -588,7 +611,7 @@ the terminal (or final) form of the letter.
 ![Final form substitution](/images/syriac/syriac-fina.png)
 
 
-#### 4.4 fin2 ####
+#### 5.4 fin2 ####
 
 The `fin2` feature replaces word-final Alaph glyph that are not
 preceded by Dalath, Rish, or dotless Dalath-Rish with a special
@@ -597,7 +620,7 @@ terminal form.
 ![Final form-2 substitution](/images/syriac/syriac-fin2.png)
 
 
-#### 4.5 fin3 ####
+#### 5.5 fin3 ####
 
 The `fin3` feature replaces word-final Alaph glyph that are 
 preceded by Dalath, Rish, or dotless Dalath-Rish with a special
@@ -606,7 +629,7 @@ terminal form.
 ![Final form-3 substitution](/images/syriac/syriac-fin3.png)
 
 
-#### 4.6 medi ####
+#### 5.6 medi ####
 
 The `medi` feature substitutes the default glyph for a codepoint with
 the medial form of the letter.
@@ -614,7 +637,7 @@ the medial form of the letter.
 ![Medial form substitution](/images/syriac/syriac-medi.png)
 
 
-#### 4.7 med2 ####
+#### 5.7 med2 ####
 
 The `med2` feature replaces Alaph glyphs in the middle of a
 word that are preceded by a base character that cannot be joined to
@@ -623,7 +646,7 @@ with a special medial form.
 ![Medial form-2 substitution](/images/syriac/syriac-med2.png)
 
 
-#### 4.8 init ####
+#### 5.8 init ####
 
 The `init` feature substitutes the default glyph for a codepoint with
 the initial form of the letter.
@@ -631,7 +654,7 @@ the initial form of the letter.
 ![Initial form substitution](/images/syriac/syriac-init.png)
 
 
-#### 4.9 rlig ####
+#### 5.9 rlig ####
 
 The `rlig` feature substitutes glyph sequences with mandatory
 ligatures. Substitutions made by `rlig` cannot be disabled by
@@ -640,12 +663,12 @@ application-level user interfaces.
 ![Required ligature substitution](/images/syriac/syriac-rlig.png)
 
 
-#### 4.10 rclt ####
+#### 5.10 rclt ####
 
 This feature is not used in `<syrc>` text.
 
 
-#### 4.11 calt ####
+#### 5.11 calt ####
 
 The `calt` feature substitutes glyphs with contextual alternate
 forms. In general, this involves replacing the default form of a
@@ -659,7 +682,7 @@ can be disabled by application-level user interfaces.
 
 
 
-### 5. Applying the typographic-form substitution features from GSUB ###
+### 6. Applying the typographic-form substitution features from GSUB ###
 
 The typographic-substitution phase applies optional substitution
 features using the rules in the font's GSUB table.
@@ -673,7 +696,7 @@ all scripts implemented in the Arabic shaping model:
 	mset (not used in Syriac)
 	
 
-#### 5.1 liga ####
+#### 6.1 liga ####
 
 The `liga` feature substitutes standard, optional ligatures that are on
 by default. Substitutions made by `liga` may be disabled by
@@ -683,53 +706,22 @@ application-level user interfaces.
 
 
 
-#### 5.2 dlig ####
+#### 6.2 dlig ####
 
 The `dlig` feature substitutes additional optional ligatures that are
 off by default. Substitutions made by `dlig` may be disabled by
 application-level user interfaces.
 
 
-#### 5.3 cswh ####
+#### 6.3 cswh ####
 
 This feature is not used in `<syrc>` text.
 
 
-#### 5.4 mset ####
+#### 6.4 mset ####
 
 This feature is not used in `<syrc>` text.
 
-
-### 6. Mark reordering ###
-
-<!--- http://www.unicode.org/reports/tr53/tr53-1.pdf --->
-
-Sequences of adjacent marks must be reordered so that they appear in
-canonical order before the mark-to-base and mark-to-mark positioning
-features from GPOS can be correctly applied.
-
-> Note: The following algorithm contains steps specific to reordering
-> Arabic marks. Since Garshuni text, which uses the Syriac script to
-> write the Arabic language, employs Arabic marks, shaping engines
-> should not omit the mark-reordering logic. 
-
-In particular, those marks that have strong affinity to the base
-character must be placed closest to the base.
-
-The algorithm for reordering a sequence of marks is:
-
-  - First, move any "Shadda" (combining class `33`) characters to the
-    beginning of the mark sequence.
-	
-  -	Second, move any subsequence of combining-class-`230` characters that begins
-       with a `230_MCM` character to the beginning of the sequence,
-       before all "Shadda" characters. The subsequence must be moved
-       as a group.
-
-  - Finally, move any subsequence of combining-class-`220` characters that begins
-       with a `220_MCM` character to the beginning of the sequence,
-       before all "Shadda" characters and before all class-`230`
-       characters. The subsequence must be moved as a group.
 
 ### 7. Applying the positioning features from GPOS ###
 


### PR DESCRIPTION
This moves the AMTRA transient-mark-reordering stage to early in the Arabic model, while hopefully maintaining the distinction between it and the NFD/NFC generic mark reordering.