### PR TITLE
Handle standalone explicit reph

### DIFF
--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -330,11 +330,17 @@ conjunct, the zero-width non-joiner (ZWNJ) must be used instead.
     "Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
-"Reph". 
+"Reph" in those scripts that use an implicit sequence to request a
+"Reph" form.
 
   - An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
     even where an initial "Ra,Halant" sequence without the zero-width
     joiner would otherwise produce a "Reph".
+
+> Note: this particular usage of ZWJ may not apply to scripts that
+> feature an explicit "Reph" codepoint or an explicit sequence for
+> requesting "Reph". See the script-specific shaping documents for
+> full details.
 
 The ZWJ and ZWNJ characters are, by definition, non-printing control
 characters and have the _Default_Ignorable_ property in the Unicode
@@ -855,9 +861,10 @@ to recognize these sequences and not mis-identify the base consonant.
 In Indic scripts, the consonant "Ra" receives special treatment; in
 many circumstances it is replaced by one of two combining mark-like forms. 
 
-  - A "Ra,Halant" sequence at the beginning of a syllable may be replaced
-    with an above-base mark called "Reph" (unless the "Ra" is the only
-    consonant in the syllable). 
+  - A "Ra,Halant" or "Ra,Halant,ZWJ" sequence at the beginning of a
+    syllable may be replaced with an above-base mark called "Reph"
+    (although script-specifics rules may negate this replacement if
+    the "Ra" is the only consonant in the syllable). 
 
   - "Halant,Ra" sequences that occur elsewhere in the syllable may
     take on a below-base form (called "Rakaar" in Devanagari and most
@@ -1303,8 +1310,9 @@ that will become "Reph"s:
 
 #### 2.6: Reph ####
 
-Sixth, initial "Ra,Halant" sequences that will become "Reph"s must be tagged with
-`POS_RA_TO_BECOME_REPH`.
+Sixth, initial "Ra,Halant" (in `REPH_MODE_IMPLICIT` scripts) or
+"Ra,Halant,ZWJ" (in `REPH_MODE_EXPLICIT` scripts) sequences that will
+become "Reph"s must be tagged with `POS_RA_TO_BECOME_REPH`.
 
 #### 2.7: Post-base consonants ####
 

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -443,8 +443,7 @@ treatment; in many circumstances it is replaced by a combining
 mark-like form. 
 
   - A "Ra,Halant,ZWJ" sequence at the beginning of a syllable
-    is replaced with an above-base mark called "Reph" (unless the "Ra"
-    is the only consonant in the syllable). 
+    is replaced with an above-base mark called "Reph". 
     This rule is synonymous with the `REPH_MODE_EXPLICIT`
     characteristic mentioned earlier.
 
@@ -793,9 +792,8 @@ different algorithm is required for the shaper to identify the base
 consonant of a syllable. The algorithm for determining the base
 consonant in Sinhala is
 
-  - If the syllable starts with "Ra,Halant,ZWJ" and the syllable contains
-    more than one consonant, exclude the starting "Ra" from the list of
-    consonants to be considered. 
+  - If the syllable starts with "Ra,Halant,ZWJ", exclude the starting
+    "Ra" from the list of consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is immediately preceded by a ZWJ, move to the
         previous consonant. If the consonant is not immediately
@@ -898,8 +896,7 @@ with `POS_PREBASE_CONSONANT`.
 Sixth, initial "Ra,Halant,ZWJ" sequences that will become "Reph"s must be tagged with
 `POS_RA_TO_BECOME_REPH`.
 
-> Note: an initial "Ra,Halant,ZWJ" sequence will always become a "Reph"
-> unless the "Ra" is the only consonant in the syllable.
+> Note: an initial "Ra,Halant,ZWJ" sequence will always become a "Reph".
 
 #### 2.7: Post-base consonants ####
 

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -487,8 +487,7 @@ treatment; in many circumstances it is replaced by a combining
 mark-like form. 
 
   - A "Ra,Halant,ZWJ" sequence at the beginning of a syllable is replaced
-    with a right-side mark called "Reph" (unless the "Ra" is the only
-    consonant in the syllable). This rule is synonymous with the
+    with a right-side mark called "Reph". This rule is synonymous with the
     `REPH_MODE_EXPLICIT` characteristic mentioned earlier.
   - A post-base "Ra" is reordered to before the base consonant or
     syllable base during the final-reordering stage of the shaping
@@ -878,9 +877,8 @@ encountered during the base-consonant search must be tagged
 
 The algorithm for determining the base consonant is
 
-  - If the syllable starts with "Ra,Halant" and the syllable contains
-    more than one consonant, exclude the starting "Ra" from the list of
-    consonants to be considered. 
+  - If the syllable starts with "Ra,Halant,ZWJ", exclude the starting
+    "Ra" from the list of consonants to be considered. 
   - Starting from the end of the syllable, move backwards until a consonant is found.
       * If the consonant is the first consonant, stop.
       * If the consonant is preceded by the sequence "Halant,ZWJ", stop.
@@ -984,7 +982,7 @@ matched later in the shaping process.
 #### 2.5: Pre-base consonants ####
 
 Fifth, consonants that occur before the syllable base must be tagged
-with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant" sequences
+with `POS_PREBASE_CONSONANT`. Excluding initial "Ra,Halant,ZWJ" sequences
 that will become "Reph"s: 
 
   - If the consonant has a below-base form, tag it as
@@ -1022,8 +1020,7 @@ because it is part of the general processing scheme for shaping Indic scripts.
 Sixth, initial "Ra,Halant,ZWJ" sequences that will become "Reph"s must be tagged with
 `POS_RA_TO_BECOME_REPH`.
 
-> Note: an initial "Ra,Halant,ZWJ" sequence will always become a "Reph"
-> unless the "Ra" is the only consonant in the syllable.
+> Note: an initial "Ra,Halant,ZWJ" sequence will always become a "Reph".
 
 #### 2.7: Final consonants ####
 


### PR DESCRIPTION
This updates the two Indic2 script docs that use `REPH_MODE_EXPLICIT`, in light of #81. Believed to be the correct behavior for Sinhala, but a little less clear for Telugu, considering that Telugu's explicit-Reph-request sequence is only used for old orthography.

Also patches in some related references in the Indic-General doc.