### PR TITLE
Indic2: update regexes to disallow matras after C,H,ZWJ

### DIFF
--- a/notes/uniscribe-bug-compatibility.md
+++ b/notes/uniscribe-bug-compatibility.md
@@ -17,6 +17,7 @@ regarded as bugs by end users.
       - [Bengali init feature matching](#bengali-init-feature-matching)
       - [Old-model post-base Halant reordering](#old-model-post-base-halant-reordering)
       - [Halants and left matras](#halants-and-left-matras)
+	  - [Explicit half-forms followed by matras](#explicit-half-forms-followed-by-matras)
 
 
 Compatibility notes in the "miscellaneous" category deal with
@@ -195,3 +196,36 @@ This check is required for shaping Sinhala, because the `U+0DDA`
 multi-part matra decomposes into the sequence "`U+0DD9`,Halant". The
 decomposed Halant should remain where it is, serving as the right-side
 matra component.
+
+
+### Explicit half-forms followed by matras ###
+
+As a general rule, Uniscribe and other shapers insert a dotted-circle
+character before a non-spacing mark character (such as a matra in
+Indic2-model scripts) when that non-spacing mark character is not
+matched with a base character in a permitted syllable. In such
+circumstances, the dotted-circle visually serves to communicate to
+readers that a base character has not been found, and also
+functionally serves as a surrogate base on which the mark character
+can be positioned.
+
+However, Uniscribe is known not to insert a dotted-circle before a
+matra character when it is preceded by two sequential
+explicit-half-form sequences (meaning two consecutive occurrences of
+"_Consonant_,Halant,ZWJ") in Indic2 runs.
+
+Therefore, the sequence:
+
+    `_Consonant_,Halant,ZWJ,_matra_`
+
+would be transformed to:
+
+    `_Consonant_,Halant,ZWJ,Dotted-Circle,_matra_`
+
+but the sequence:
+
+    `_Consonant_,Halant,ZWJ,_Consonant_,Halant,ZWJ,_matra_`
+
+would _not_ be transformed with a dotted-circle insertion.
+
+This exception is regarded as a likely bug.

--- a/opentype-shaping-bengali.md
+++ b/opentype-shaping-bengali.md
@@ -621,7 +621,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to

--- a/opentype-shaping-devanagari.md
+++ b/opentype-shaping-devanagari.md
@@ -588,7 +588,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to

--- a/opentype-shaping-gujarati.md
+++ b/opentype-shaping-gujarati.md
@@ -575,7 +575,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to

--- a/opentype-shaping-gurmukhi.md
+++ b/opentype-shaping-gurmukhi.md
@@ -631,7 +631,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -977,7 +977,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to

--- a/opentype-shaping-indic-general.md
+++ b/opentype-shaping-indic-general.md
@@ -625,7 +625,7 @@ table:
 | Oriya      | `REPH_POS_AFTER_MAIN`      |
 | Tamil      | `REPH_POS_AFTER_POST`      |
 | Telugu     | `REPH_POS_AFTER_POST`      |
-| Sinhala    | `REPH_POS_AFTER_MAIN`      |
+| Sinhala    | `REPH_POS_AFTER_POST`      |
 
 
 

--- a/opentype-shaping-kannada.md
+++ b/opentype-shaping-kannada.md
@@ -592,7 +592,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to

--- a/opentype-shaping-malayalam.md
+++ b/opentype-shaping-malayalam.md
@@ -634,7 +634,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to

--- a/opentype-shaping-oriya.md
+++ b/opentype-shaping-oriya.md
@@ -632,7 +632,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -360,7 +360,8 @@ characteristics include:
      consonant in `<sinh>` text differs from that used by other
      `BASE_POS_LAST` scripts.
 
-  - `REPH_POS_AFTER_MAIN` = "Reph" is ordered after the base consonant or syllable base.
+  - `REPH_POS_AFTER_POST` = "Reph" is ordered after the last post-base
+     consonant form.
 
   - `REPH_MODE_EXPLICIT` = "Reph" is formed by an initial "Ra,Halant,ZWJ" sequence.
 
@@ -1239,9 +1240,9 @@ the base consonant or syllable base, and all half forms.
 #### 4.3: Reph ####
 
 "Reph" must be moved from the beginning of the syllable to its final
-position. Because Sinhala incorporates the `REPH_POS_AFTER_MAIN`
-shaping characteristic, this final position is immediately after the
-syllable base.
+position. Because Sinhala incorporates the `REPH_POS_AFTER_POST`
+shaping characteristic, this final position is defined to be
+immediately after any post-base consonant forms.
 
 The algorithm for finding the final "Reph" position is
 
@@ -1252,10 +1253,10 @@ The algorithm for finding the final "Reph" position is
     2](#2-initial-reordering)). This will be the final "Reph"
     position. 
 	> Note: Because Sinhala incorporates the
-    > `REPH_POS_AFTER_MAIN` shaping characteristic, this means
-    > any positioning tag of `POS_ABOVEBASE_CONSONANT` or later,
+    > `REPH_POS_AFTER_POST` shaping characteristic, this means
+    > any positioning tag of `POS_FINAL_CONSONANT` or later,
     > although a post-base matra, syllable modifier, or Vedic sign
-    > would not typically be tagged with `POS_ABOVEBASE_CONSONANT`.
+    > would not typically be tagged with `POS_FINAL_CONSONANT`.
   - If no other location has been located in the previous step, move
     the "Reph" to the end of the syllable.
 

--- a/opentype-shaping-sinhala.md
+++ b/opentype-shaping-sinhala.md
@@ -551,7 +551,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to

--- a/opentype-shaping-tamil.md
+++ b/opentype-shaping-tamil.md
@@ -585,7 +585,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to

--- a/opentype-shaping-telugu.md
+++ b/opentype-shaping-telugu.md
@@ -605,7 +605,7 @@ SYLLABLE_TAIL	= (Z? _syllablemodifier_ _syllablemodifier_? _zwnj_?)? _vedicsign_
 HALANT_GROUP	= Z? _halant_ (_zwj_ _nukta_?)?
 FINAL_HALANT_GROUP	= HALANT_GROUP | (_halant_ _zwnj_)
 MEDIAL_GROUP	= _consonantmedial_?
-HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | ((_halant_ _zwj_)? MATRA_GROUP*)
+HALANT_OR_MATRA_GROUP	= FINAL_HALANT_GROUP | MATRA_GROUP*)
 ```
 
 > Note: Practically speaking, shaping engines are highly unlikely to


### PR DESCRIPTION
This fixes #72, bringing the docs back up to the same regular expressions used by HarfBuzz.

The essence is that a "_Consonant_,Halant,ZWJ,_matra_" sequence should get a dotted circle inserted just before the matra. Previously, this was not done because testing indicated that Uniscribe also did not insert the dotted-circle. Subsequent testing by HarfBuzz maintainers, however, narrowed down the Uniscribe behavior to be limited to "_Consonant_,Halant,ZWJ,_Consonant_,Halant,ZWJ,_matra_" cases (that is, two explicit half forms, followed by a matra).

That situation is almost certainly a bug, and only of interest to shapers targeting rigorous equivalence with Uniscribe. The MS specifications do not permit that.

So, this PR updates the regular expressions to match the updated versions in HarfBuzz (which no longer permit the "_Consonant_,Halant,ZWJ,_matra_" to match, and it notes the condition and reasoning in the Uniscribe-compatibility document.