### PR TITLE
Unicode 15 additions

### DIFF
--- a/character-tables/character-tables-arabic.md
+++ b/character-tables/character-tables-arabic.md
@@ -9,6 +9,7 @@ This document lists the per-character shaping information needed to
   - [Arabic Supplement character table](#arabic-supplement-character-table)
   - [Arabic Extended-A character table](#arabic-extended-a-character-table)
   - [Arabic Extended-B character table](#arabic-extended-b-character-table)
+  - [Arabic Extended-C character table](#arabic-extended-c-character-table)
   - [Rumi Numeral Symbols character table](#rumi-numeral-symbols-character-table)
   - [Miscellaneous character table](#miscellaneous-character-table)
 
@@ -543,6 +544,81 @@ treated differently during the mark-reordering stage.
 |`U+089D`   | Mark [Mn]        | TRANSPARENT  | _null_               | 230        | &#x089D; Superscript Alef Mokhassas                   |
 |`U+089E`   | Mark [Mn]        | TRANSPARENT  | _null_               | 230        | &#x089E; Doubled Madda                                |
 |`U+089F`   | Mark [Mn]        | TRANSPARENT  | _null_               | 230        | &#x089F; Half Madda Over Madda                        |
+| | | | | |
+
+
+## Arabic Extended-C character table ##
+
+
+| Codepoint | Unicode category | Joining type | Joining group        | Mark class | Glyph                                                 |
+|:----------|:-----------------|:-------------|:---------------------|:-----------|-------------------------------------------------------|
+|`U+10EC0`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EC1`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EC2`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EC3`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EC4`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EC5`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EC6`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EC7`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EC8`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EC9`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ECA`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ECB`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ECC`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ECD`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ECE`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ECF`  | _unassigned_     |              |                      |            |                                                       |
+| | | | | |
+|`U+10ED0`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ED1`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ED2`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ED3`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ED4`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ED5`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ED6`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ED7`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ED8`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10ED9`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EDA`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EDB`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EDC`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EDD`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EDE`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EDF`  | _unassigned_     |              |                      |            |                                                       |
+| | | | | |
+|`U+10EE0`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EE1`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EE2`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EE3`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EE4`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EE5`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EE6`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EE7`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EE8`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EE9`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EEA`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EEB`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EEC`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EED`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EEE`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EEF`  | _unassigned_     |              |                      |            |                                                       |
+| | | | | |
+|`U+10EF0`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EF1`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EF2`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EF3`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EF4`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EF5`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EF6`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EF7`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EF8`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EF9`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EFA`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EFB`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EFC`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EFD`  | Mark [Mn]        | TRANSPARENT  | _null_               | 220        | &#x10EFD; Small Low Word Sakta                        |
+|`U+10EFE`  | Mark [Mn]        | TRANSPARENT  | _null_               | 220        | &#x10EFE; Small Low Word Qasr                         |
+|`U+10EFF`  | Mark [Mn]        | TRANSPARENT  | _null_               | 220        | &#x10EFF; Small Low Word Madda                        |
 | | | | | |
 
 

--- a/character-tables/character-tables-devanagari.md
+++ b/character-tables/character-tables-devanagari.md
@@ -220,6 +220,118 @@ specific, script-aware behavior.
 |`U+A8FD`   | Letter           | _null_            | _null_                     | &#xA8FD; Jain Om             |
 |`U+A8FE`   | Letter           | VOWEL_INDEPENDENT | _null_                     | &#xA8FE; Ay                  |
 |`U+A8FF`   | Mark [Mn]        | VOWEL_DEPENDENT   | TOP_POSITION               | &#xA8FF; Sign Ay             |
+| | | | |
+
+
+
+## Devanagari Extended-A character table ##
+
+| Codepoint | Unicode category | Shaping class | Mark-placement subclass | Glyph                                   |
+|:----------|:-----------------|:--------------|:------------------------|:----------------------------------------|
+| `U+11B00` | Punctuation      | _null_        | _null_                  | &#x11B00; Head Mark                     |
+| `U+11B01` | Punctuation      | _null_        | _null_                  | &#x11B01; Head Mark With Headstroke     |
+| `U+11B02` | Punctuation      | _null_        | _null_                  | &#x11B02; Sign Bhale                    |
+| `U+11B03` | Punctuation      | _null_        | _null_                  | &#x11B03; Sign Bhale With Hook          |
+| `U+11B04` | Punctuation      | _null_        | _null_                  | &#x11B04; Sign Extended Bhale           |
+| `U+11B05` | Punctuation      | _null_        | _null_                  | &#x11B05; Sign Extended Bhale With Hook |
+| `U+11B06` | Punctuation      | _null_        | _null_                  | &#x11B06; Sign Western Five-like Bhale  |
+| `U+11B07` | Punctuation      | _null_        | _null_                  | &#x11B07; Sign Western Nine-like Bhale  |
+| `U+11B08` | Punctuation      | _null_        | _null_                  | &#x11B08; Sign Reversed Nine-like Bhale |
+| `U+11B09` | Punctuation      | _null_        | _null_                  | &#x11B09; Sign Mindu                    |
+| `U+11B0A` | _unassigned_     |               |                         |                                         |
+| `U+11B0B` | _unassigned_     |               |                         |                                         |
+| `U+11B0C` | _unassigned_     |               |                         |                                         |
+| `U+11B0D` | _unassigned_     |               |                         |                                         |
+| `U+11B0E` | _unassigned_     |               |                         |                                         |
+| `U+11B0F` | _unassigned_     |               |                         |                                         |
+|           |                  |               |                         |                                         |
+| `U+11B10` | _unassigned_     |               |                         |                                         |
+| `U+11B11` | _unassigned_     |               |                         |                                         |
+| `U+11B12` | _unassigned_     |               |                         |                                         |
+| `U+11B13` | _unassigned_     |               |                         |                                         |
+| `U+11B14` | _unassigned_     |               |                         |                                         |
+| `U+11B15` | _unassigned_     |               |                         |                                         |
+| `U+11B16` | _unassigned_     |               |                         |                                         |
+| `U+11B17` | _unassigned_     |               |                         |                                         |
+| `U+11B18` | _unassigned_     |               |                         |                                         |
+| `U+11B19` | _unassigned_     |               |                         |                                         |
+| `U+11B1A` | _unassigned_     |               |                         |                                         |
+| `U+11B1B` | _unassigned_     |               |                         |                                         |
+| `U+11B1C` | _unassigned_     |               |                         |                                         |
+| `U+11B1D` | _unassigned_     |               |                         |                                         |
+| `U+11B1E` | _unassigned_     |               |                         |                                         |
+| `U+11B1F` | _unassigned_     |               |                         |                                         |
+|           |                  |               |                         |                                         |
+| `U+11B20` | _unassigned_     |               |                         |                                         |
+| `U+11B21` | _unassigned_     |               |                         |                                         |
+| `U+11B22` | _unassigned_     |               |                         |                                         |
+| `U+11B23` | _unassigned_     |               |                         |                                         |
+| `U+11B24` | _unassigned_     |               |                         |                                         |
+| `U+11B25` | _unassigned_     |               |                         |                                         |
+| `U+11B26` | _unassigned_     |               |                         |                                         |
+| `U+11B27` | _unassigned_     |               |                         |                                         |
+| `U+11B28` | _unassigned_     |               |                         |                                         |
+| `U+11B29` | _unassigned_     |               |                         |                                         |
+| `U+11B2A` | _unassigned_     |               |                         |                                         |
+| `U+11B2B` | _unassigned_     |               |                         |                                         |
+| `U+11B2C` | _unassigned_     |               |                         |                                         |
+| `U+11B2D` | _unassigned_     |               |                         |                                         |
+| `U+11B2E` | _unassigned_     |               |                         |                                         |
+| `U+11B2F` | _unassigned_     |               |                         |                                         |
+|           |                  |               |                         |                                         |
+| `U+11B30` | _unassigned_     |               |                         |                                         |
+| `U+11B31` | _unassigned_     |               |                         |                                         |
+| `U+11B32` | _unassigned_     |               |                         |                                         |
+| `U+11B33` | _unassigned_     |               |                         |                                         |
+| `U+11B34` | _unassigned_     |               |                         |                                         |
+| `U+11B35` | _unassigned_     |               |                         |                                         |
+| `U+11B36` | _unassigned_     |               |                         |                                         |
+| `U+11B37` | _unassigned_     |               |                         |                                         |
+| `U+11B38` | _unassigned_     |               |                         |                                         |
+| `U+11B39` | _unassigned_     |               |                         |                                         |
+| `U+11B3A` | _unassigned_     |               |                         |                                         |
+| `U+11B3B` | _unassigned_     |               |                         |                                         |
+| `U+11B3C` | _unassigned_     |               |                         |                                         |
+| `U+11B3D` | _unassigned_     |               |                         |                                         |
+| `U+11B3E` | _unassigned_     |               |                         |                                         |
+| `U+11B3F` | _unassigned_     |               |                         |                                         |
+|           |                  |               |                         |                                         |
+| `U+11B40` | _unassigned_     |               |                         |                                         |
+| `U+11B41` | _unassigned_     |               |                         |                                         |
+| `U+11B42` | _unassigned_     |               |                         |                                         |
+| `U+11B43` | _unassigned_     |               |                         |                                         |
+| `U+11B44` | _unassigned_     |               |                         |                                         |
+| `U+11B45` | _unassigned_     |               |                         |                                         |
+| `U+11B46` | _unassigned_     |               |                         |                                         |
+| `U+11B47` | _unassigned_     |               |                         |                                         |
+| `U+11B48` | _unassigned_     |               |                         |                                         |
+| `U+11B49` | _unassigned_     |               |                         |                                         |
+| `U+11B4A` | _unassigned_     |               |                         |                                         |
+| `U+11B4B` | _unassigned_     |               |                         |                                         |
+| `U+11B4C` | _unassigned_     |               |                         |                                         |
+| `U+11B4D` | _unassigned_     |               |                         |                                         |
+| `U+11B4E` | _unassigned_     |               |                         |                                         |
+| `U+11B4F` | _unassigned_     |               |                         |                                         |
+|           |                  |               |                         |                                         |
+| `U+11B50` | _unassigned_     |               |                         |                                         |
+| `U+11B51` | _unassigned_     |               |                         |                                         |
+| `U+11B52` | _unassigned_     |               |                         |                                         |
+| `U+11B53` | _unassigned_     |               |                         |                                         |
+| `U+11B54` | _unassigned_     |               |                         |                                         |
+| `U+11B55` | _unassigned_     |               |                         |                                         |
+| `U+11B56` | _unassigned_     |               |                         |                                         |
+| `U+11B57` | _unassigned_     |               |                         |                                         |
+| `U+11B58` | _unassigned_     |               |                         |                                         |
+| `U+11B59` | _unassigned_     |               |                         |                                         |
+| `U+11B5A` | _unassigned_     |               |                         |                                         |
+| `U+11B5B` | _unassigned_     |               |                         |                                         |
+| `U+11B5C` | _unassigned_     |               |                         |                                         |
+| `U+11B5D` | _unassigned_     |               |                         |                                         |
+| `U+11B5E` | _unassigned_     |               |                         |                                         |
+| `U+11B5F` | _unassigned_     |               |                         |                                         |
+|           |                  |               |                         |                                         |
+
+
 
 
 

--- a/character-tables/character-tables-kannada.md
+++ b/character-tables/character-tables-kannada.md
@@ -137,7 +137,7 @@ specific, script-aware behavior.
 |`U+0CDA`   | _unassigned_     |                   |                            |                              |
 |`U+0CDB`   | _unassigned_     |                   |                            |                              |
 |`U+0CDC`   | _unassigned_     |                   |                            |                              |
-|`U+0CDD`   | Letter           | CONSONANT_DEAD    | _null_                     | &#x0CDD; Nakaara Pollu       |
+|`U+0CDD`   | _unassigned_     |                   |                            |                              |
 |`U+0CDE`   | Letter           | CONSONANT         | _null_                     | &#x0CDE; Fa                  |
 |`U+0CDF`   | _unassigned_     |                   |                            |                              |
 | | | | |																		
@@ -161,7 +161,7 @@ specific, script-aware behavior.
 |`U+0CF0`   | _unassigned_     |                   |                            |                              |
 |`U+0CF1`   | Letter           | CONSONANT_WITH_STACKER | _null_                | &#x0CF1; Jihvamuliya         |
 |`U+0CF2`   | Letter           | CONSONANT_WITH_STACKER | _null_                | &#x0CF2; Upadhmaniya         |
-|`U+0CF3`   | _unassigned_     |                   |                            |                              |
+|`U+0CF3`   | Mark [Mc]        | BINDU             | RIGHT_POSITION             | &#x0CF3; Combining Anusvara Above Right|
 |`U+0CF4`   | _unassigned_     |                   |                            |                              |
 |`U+0CF5`   | _unassigned_     |                   |                            |                              |
 |`U+0CF6`   | _unassigned_     |                   |                            |                              |
@@ -281,28 +281,27 @@ this situation gracefully.
 |`U+25CC`   | Symbol           | DOTTED_CIRCLE     | _null_                     | &#x25CC; Dotted circle         |
 
 
-The zero-width joiner (ZWJ) is primarily used to prevent the formation
-of a conjunct from a "_Consonant_,Halant,_Consonant_" sequence. The
-sequence "_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of
-a conjunct between the two consonants. 
+The zero-width joiner is primarily used to prevent the formation of a conjunct
+from a "_Consonant_,Halant,_Consonant_" sequence. The sequence
+"_Consonant_,Halant,ZWJ,_Consonant_" blocks the formation of a
+conjunct between the two consonants. 
 
 Note, however, that the "_Consonant_,Halant" subsequence in the above
 example may still trigger a half-forms feature. To prevent the
 application of the half-forms feature in addition to preventing the
-conjunct, the zero-width non-joiner (ZWNJ) must be used instead. The
-sequence "_Consonant_,Halant,ZWNJ,_Consonant_" should produce the
-first consonant in its standard form, followed by an explicit
-"Halant".
+conjunct, the zero-width non-joiner must be used instead. The sequence
+"_Consonant_,Halant,ZWNJ,_Consonant_" should produce the first
+consonant in its standard form, followed by an explicit "Halant".
 
 A secondary usage of the zero-width joiner is to prevent the formation of
 "Reph". An initial "Ra,Halant,ZWJ" sequence should not produce a "Reph",
 where an initial "Ra,Halant" sequence without the zero-width joiner
 otherwise would.
 
-The no-break space (NBSP) is primarily used to display those
-codepoints that are defined as non-spacing (marks, dependent vowels
-(matras), below-base consonant forms, and post-base consonant forms)
-in an isolated context, as an alternative to displaying them
-superimposed on the dotted-circle placeholder. These sequences will
-match "NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
+The no-break space is primarily used to display those codepoints that
+are defined as non-spacing (marks, dependent vowels (matras),
+below-base consonant forms, and post-base consonant forms) in an
+isolated context, as an alternative to displaying them superimposed on
+the dotted-circle placeholder. These sequences will match
+"NBSP,ZWJ,Halant,_Consonant_", "NBSP,_mark_", or "NBSP,_matra_".
 

--- a/character-tables/character-tables-lao.md
+++ b/character-tables/character-tables-lao.md
@@ -120,7 +120,7 @@ specific, script-aware behavior.
 |`U+0ECB`   | Mark [Mn]        | TONE_MARKER       | TOP_POSITION            | 122             | _null_ | &#x0ECB; Tone Mai Catawa      |
 |`U+0ECC`   | Mark [Mn]        | _null_            | TOP_POSITION            | _0_             | _null_ | &#x0ECC; Cancellation mark    |
 |`U+0ECD`   | Mark [Mn]        | BINDU             | TOP_POSITION            | _0_             | _null_ | &#x0ECD; Niggahita            |
-|`U+0ECE`   | _unassigned_     |                   |                         |                 |        |                               |
+|`U+0ECE`   | Mark [Mn]        | TONE_MARKER       | TOP_POSITION            | _0_             | _null_ | &#x0ECE; Yamakkan             |
 |`U+0ECF`   | _unassigned_     |                   |                         |                 |        |                               |
 | | | | | | | |        														                    
 |`U+0ED0`   | Number           | NUMBER            | _null_                  | _0_             | _null_ | &#x0ED0; Digit Zero           |

--- a/opentype-shaping-arabic.md
+++ b/opentype-shaping-arabic.md
@@ -207,6 +207,7 @@ used in `<arab>` text runs:
   - [Arabic Supplement character table](character-tables/character-tables-arabic.md#arabic-supplement-character-table)
   - [Arabic Extended-A character table](character-tables/character-tables-arabic.md#arabic-extended-a-character-table)
   - [Arabic Extended-B character table](character-tables/character-tables-arabic.md#arabic-extended-b-character-table)
+  - [Arabic Extended-C character table](character-tables/character-tables-arabic.md#arabic-extended-c-character-table)
   - [Rumi Numeral Symbols character table](character-tables/character-tables-arabic.md#rumi-numeral-symbols-character-table)
   - [Miscellaneous character table](character-tables/character-tables-arabic.md#miscellaneous-character-table)
 


### PR DESCRIPTION
These are the new bits from Unicode 15 for the scripts covered in these docs.

A couple of brand-new, mostly empty blocks. Not a lot total, though.

- On Arabic Extended C, my decidedly sub-novice grasp of Arabic suggests that the new codepoints, which are small-below-word notations, don't interact with shaping or with AMTRA mark handling. Similar, I'm assuming, to other word-annotation codepoints. If I'm wrong definitely let me know.
- On Devanagari Extended A, I found a lot less written that gives clues to handling, but the new codepoints all sound like they're used as full-size symbol characters, not letters and not participating in any way with syllable or cluster behavior.

Bit less clear on the Lao addition; HarfBuzz source has it classified as a syllable-modifier, which wasn't a category used elsewhere in Lao before, which probably just means I need to re-read the Lao bits. But it appears to attach only to base consonants.

The Kannada addition seems totally straightforward on Syllabic and Positional issues.

Weirdly, the announcement [post](http://blog.unicode.org/2022/09/announcing-unicode-standard-version-150.html) refers to new Latin additions used for Malayalam, which I presume is the Latin Extended G stuff, but I couldn't find any real explanation. So I'm assuming they are used only in Latin contexts and don't add processing.

This PR can simmer for a while in case somebody wanders by to spot an error; on the other hand if someone needs it merged ASAP, say the word; I'm just doing other things in the coming weeks.