### PR TITLE
Update Arabic and Myanmar for Unicode16

### DIFF
--- a/character-tables/character-tables-arabic.md
+++ b/character-tables/character-tables-arabic.md
@@ -84,7 +84,7 @@ treated differently during the mark-reordering stage.
 |`U+061E`   | Punctuation      | NON_JOINING  | _null_               | _0_        | &#x061E; Triple Dot Punctuation Mark          |
 |`U+061F`   | Punctuation      | NON_JOINING  | _null_               | _0_        | &#x061F; Question Mark                        |
 | | | | | |                                                                                                                       
-|`U+0620`   | Letter           | DUAL         | YEH                  | _0_        | &#x0620; Dotless Yeh With Separate Ring Below |
+|`U+0620`   | Letter           | DUAL         | YEH                  | _0_        | &#x0620; Kashmiri Yeh                         |
 |`U+0621`   | Letter           | NON_JOINING  | _null_               | _0_        | &#x0621; Hamza                                |
 |`U+0622`   | Letter           | RIGHT        | ALEF                 | _0_        | &#x0622; Alef With Madda Above                |
 |`U+0623`   | Letter           | RIGHT        | ALEF                 | _0_        | &#x0623; Alef With Hamza Above                |
@@ -535,7 +535,7 @@ treated differently during the mark-reordering stage.
 |`U+0894`   | _unassigned_     |              |                      |            |                                                       |
 |`U+0895`   | _unassigned_     |              |                      |            |                                                       |
 |`U+0896`   | _unassigned_     |              |                      |            |                                                       |
-|`U+0897`   | _unassigned_     |              |                      |            |                                                       |
+|`U+0897`   | Mark [Mn]        | TRANSPARENT  | _null_               | 230        | &#x0897; Pepet                                        |
 |`U+0898`   | Mark [Mn]        | TRANSPARENT  | _null_               | 230        | &#x0898; Small High Word Al-Juz                       |
 |`U+0899`   | Mark [Mn]        | TRANSPARENT  | _null_               | 220        | &#x0899; Small Low Word Ishmaam                       |
 |`U+089A`   | Mark [Mn]        | TRANSPARENT  | _null_               | 220        | &#x089A; Small Low Word Imaala                        |
@@ -554,9 +554,9 @@ treated differently during the mark-reordering stage.
 |:----------|:-----------------|:-------------|:---------------------|:-----------|-------------------------------------------------------|
 |`U+10EC0`  | _unassigned_     |              |                      |            |                                                       |
 |`U+10EC1`  | _unassigned_     |              |                      |            |                                                       |
-|`U+10EC2`  | _unassigned_     |              |                      |            |                                                       |
-|`U+10EC3`  | _unassigned_     |              |                      |            |                                                       |
-|`U+10EC4`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EC2`  | Letter           | RIGHT        | DAL                  | _0_        | &#x10EC2; Dal With Two Dots Vertically Below          |
+|`U+10EC3`  | Letter           | DUAL         | TAH                  | _0_        | &#x10EC2; Tah With Two Dots Vertically Below          |
+|`U+10EC4`  | Letter           | DUAL         | KAF                  | _0_        | &#x10EC2; Kaf With Two Dots Vertically Below          |
 |`U+10EC5`  | _unassigned_     |              |                      |            |                                                       |
 |`U+10EC6`  | _unassigned_     |              |                      |            |                                                       |
 |`U+10EC7`  | _unassigned_     |              |                      |            |                                                       |
@@ -615,7 +615,7 @@ treated differently during the mark-reordering stage.
 |`U+10EF9`  | _unassigned_     |              |                      |            |                                                       |
 |`U+10EFA`  | _unassigned_     |              |                      |            |                                                       |
 |`U+10EFB`  | _unassigned_     |              |                      |            |                                                       |
-|`U+10EFC`  | _unassigned_     |              |                      |            |                                                       |
+|`U+10EFC`  | Mark [Mn]        | TRANSPARENT  | _null_               | _0_        | &#x10EFC; Combining Alef Overlay                      |
 |`U+10EFD`  | Mark [Mn]        | TRANSPARENT  | _null_               | 220        | &#x10EFD; Small Low Word Sakta                        |
 |`U+10EFE`  | Mark [Mn]        | TRANSPARENT  | _null_               | 220        | &#x10EFE; Small Low Word Qasr                         |
 |`U+10EFF`  | Mark [Mn]        | TRANSPARENT  | _null_               | 220        | &#x10EFF; Small Low Word Madda                        |

--- a/character-tables/character-tables-myanmar.md
+++ b/character-tables/character-tables-myanmar.md
@@ -290,6 +290,61 @@ specific, script-aware behavior.
 |`U+A9FE`   | Letter           | CONSONANT         | _null_                     | &#xA9FE; Tai Laing Bha       |
 |`U+A9FF`   | _unassigned_     |                   |                            |                              |
 
+### Myanmar Extended C character table ###
+
+| Codepoint | Unicode category | Shaping class     | Mark-placement subclass    | Glyph                        |
+|:----------|:-----------------|:------------------|:---------------------------|:-----------------------------|
+|`U+116D0`  | Number           | NUMBER            | _null_                     | &#x116D0; Pao Digit Zero     |
+|`U+116D1`  | Number           | NUMBER            | _null_                     | &#x116D1; Pao Digit One      |
+|`U+116D2`  | Number           | NUMBER            | _null_                     | &#x116D2; Pao Digit Two      |
+|`U+116D3`  | Number           | NUMBER            | _null_                     | &#x116D3; Pao Digit Three    |
+|`U+116D4`  | Number           | NUMBER            | _null_                     | &#x116D4; Pao Digit Four     |
+|`U+116D5`  | Number           | NUMBER            | _null_                     | &#x116D5; Pao Digit Five     |
+|`U+116D6`  | Number           | NUMBER            | _null_                     | &#x116D6; Pao Digit Six      |
+|`U+116D7`  | Number           | NUMBER            | _null_                     | &#x116D7; Pao Digit Seven    |
+|`U+116D8`  | Number           | NUMBER            | _null_                     | &#x116D8; Pao Digit Eight    |
+|`U+116D9`  | Number           | NUMBER            | _null_                     | &#x116D9; Pao Digit Nine     |
+|`U+116DA`  | Number           | NUMBER            | _null_                     | &#x116DA; Pao Digit Zero     |
+|`U+116DB`  | Number           | NUMBER            | _null_                     | &#x116DB; Eastern Pwo Karen Digit One|
+|`U+116DC`  | Number           | NUMBER            | _null_                     | &#x116DC; Eastern Pwo Karen Digit Two|
+|`U+116DD`  | Number           | NUMBER            | _null_                     | &#x116DD; Eastern Pwo Karen Digit Three|
+|`U+116DE`  | Number           | NUMBER            | _null_                     | &#x116DE; Eastern Pwo Karen Digit Four|
+|`U+116DF`  | Number           | NUMBER            | _null_                     | &#x116DF; Eastern Pwo Karen Digit Five|
+| | | | |
+|`U+116E0`  | Number           | NUMBER            | _null_                     | &#x116D0; Eastern Pwo Karen Digit Six|
+|`U+116E1`  | Number           | NUMBER            | _null_                     | &#x116D1; Eastern Pwo Karen Digit Seven|
+|`U+116E2`  | Number           | NUMBER            | _null_                     | &#x116D2; Eastern Pwo Karen Digit Eight|
+|`U+116E3`  | Number           | NUMBER            | _null_                     | &#x116D3; Eastern Pwo Karen Digit Nine|
+|`U+116E4`  | _unassigned_     |                   |                            |                              |
+|`U+116E5`  | _unassigned_     |                   |                            |                              |
+|`U+116E6`  | _unassigned_     |                   |                            |                              |
+|`U+116E7`  | _unassigned_     |                   |                            |                              |
+|`U+116E8`  | _unassigned_     |                   |                            |                              |
+|`U+116E9`  | _unassigned_     |                   |                            |                              |
+|`U+116EA`  | _unassigned_     |                   |                            |                              |
+|`U+116EB`  | _unassigned_     |                   |                            |                              |
+|`U+116EC`  | _unassigned_     |                   |                            |                              |
+|`U+116ED`  | _unassigned_     |                   |                            |                              |
+|`U+116EE`  | _unassigned_     |                   |                            |                              |
+|`U+116EF`  | _unassigned_     |                   |                            |                              |
+| | | | |
+|`U+116F0`  | _unassigned_     |                   |                            |                              |
+|`U+116F1`  | _unassigned_     |                   |                            |                              |
+|`U+116F2`  | _unassigned_     |                   |                            |                              |
+|`U+116F3`  | _unassigned_     |                   |                            |                              |
+|`U+116F4`  | _unassigned_     |                   |                            |                              |
+|`U+116F5`  | _unassigned_     |                   |                            |                              |
+|`U+116F6`  | _unassigned_     |                   |                            |                              |
+|`U+116F7`  | _unassigned_     |                   |                            |                              |
+|`U+116F8`  | _unassigned_     |                   |                            |                              |
+|`U+116F9`  | _unassigned_     |                   |                            |                              |
+|`U+116FA`  | _unassigned_     |                   |                            |                              |
+|`U+116FB`  | _unassigned_     |                   |                            |                              |
+|`U+116FC`  | _unassigned_     |                   |                            |                              |
+|`U+116FD`  | _unassigned_     |                   |                            |                              |
+|`U+116FE`  | _unassigned_     |                   |                            |                              |
+|`U+116FF`  | _unassigned_     |                   |                            |                              |
+
 
 
 ## Vedic Extensions character table ##

--- a/opentype-shaping-arabic.md
+++ b/opentype-shaping-arabic.md
@@ -394,9 +394,9 @@ The algorithm for reordering a sequence of marks is:
        characters. The subsequence must be moved as a group.
 
 > Note: Unicode describes this mark-reordering operation, the Arabic
-> Mark Transient Reordering Algorithm (<abbr>AMTRA</abbr>), in Technical Report 53,
-> which describes it in terms that are distinct from standard,
-> Ccc-based mark reordering.
+> Mark Transient Reordering Algorithm (<abbr>AMTRA</abbr>), in Unicode
+> Standard Annex 53, which describes it in terms that are distinct
+> from standard, Ccc-based mark reordering.
 >
 > Specifically, <abbr>AMTRA</abbr> is designated as an operation performed during
 > text rendering only, which therefore does not impact other

--- a/opentype-shaping-myanmar.md
+++ b/opentype-shaping-myanmar.md
@@ -257,6 +257,7 @@ are used in `<mym2>` text runs:
   - [Myanmar character table](character-tables/character-tables-myanmar.md#myanmar-character-table)
   - [Myanmar Extended-A character table](character-tables/character-tables-myanmar.md#myanmar-extended-a-character-table)
   - [Myanmar Extended-B character table](character-tables/character-tables-myanmar.md#myanmar-extended-b-character-table)
+  - [Myanmar Extended-C character table](character-tables/character-tables-myanmar.md#myanmar-extended-c-character-table)
   - [Vedic Extensions character table](character-tables/character-tables-myanmar.md#vedic-extensions-character-table)
   - [Miscellaneous character table](character-tables/character-tables-myanmar.md#miscellaneous-character-table)
 


### PR DESCRIPTION
Updates to character tables and minor text corrections for Arabic and Myanmar. There may also be some additional updates in Unicode 16 in emoji sequence handling; if so, those will be addressed separately.